### PR TITLE
Webc 442 migrate to GitHub setup tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vendor
 /release/magento
 /release/magento1702.zip
 cloud-integration-magento-*.tgz
+verbose-report.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,47 @@
 dist: precise
-sudo: false
+sudo: required
 language: php
+services:
+  - mysql
+install:
+  - phpenv config-rm xdebug.ini || return 0
+  - composer install --no-dev -d ${TRAVIS_BUILD_DIR}/src/lib/Shopgate/cloud-integration-magento-oauth2
+  # handles node update, do not move to script
+  - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install 8.4
+
+php:
+  - 5.3 #todo-sg: upgrade oAuth extension to v1.11 when it is available
+  - 5.4
+  - 5.5
+  - 5.6
 
 before_script:
-- phpenv config-rm xdebug.ini || return 0
-- composer install
+  - if [[ "$TRAVIS_TAG" ]] || [ "$TRAVIS_EVENT_TYPE" != "push" ]; then
+      chmod +x ./tests/postman/test_env_setup.sh;
+      ./tests/postman/test_env_setup.sh;
+    fi
+script:
+  - if [[ "$TRAVIS_TAG" ]] || [ "$TRAVIS_EVENT_TYPE" != "push" ]; then
+      chmod +x ./tests/postman/magento_setup.sh;
+      ./tests/postman/magento_setup.sh;
+      cd ${TRAVIS_BUILD_DIR}/tests/postman/newman;
+      newman run ./collection.json -g ./globals.json --insecure --reporters json,cli --reporter-json-export verbose-report.json --reporter-cli-no-assertions --color --global-var "domain=http://travis.dev/${MAGE_FOLDER}/" --global-var "username=${USER1_EMAIL}" --global-var "password=${USER_PASS}" --global-var "mage_type=${MAGE_TYPE}" --global-var "client_id=${CFG_API_CUSTOMER_NUMBER}-${CFG_API_SHOP_NUMBER}" --global-var "client_secret=${CFG_API_KEY}";
+    fi
+after_failure:
+  # one can check for a link in the terminal as this report file is uploaded to that link
+  - curl --upload-file ./verbose-report.json https://transfer.sh/verbose-report.json
+  - sudo less -FX /var/log/apache2/error.log
 
 jobs:
   include:
-  - stage: deploy
-    php: 5.6
-    before_script:
-      - sudo apt-get install xmlstarlet
-    script:
-      - if [[ "$TRAVIS_TAG" ]]; then ./release/build_release_package.sh ; fi
-    deploy:
+    - stage: deploy
+      php: 5.6
+      before_script:
+        - sudo apt-get install xmlstarlet
+      script:
+        - if [[ "$TRAVIS_TAG" ]]; then
+            ./release/build_release_package.sh;
+          fi
       provider: releases
       api_key: ${GITHUB_TOKEN}
       file: cloud-integration-magento-${TRAVIS_TAG}.tgz
@@ -24,7 +51,26 @@ jobs:
 
 notifications:
   slack:
-    rooms:
-      secure: y40pECJxcziSDPLqL/xjAUYR2wcgEYK8lLAh+qGrwwnQd19PVqZzcht0LfPiFC0HHO+lULvzwBZe1iMLLt91h2IDKvtkXHrwPIOr5RJiciPifKnhA/QK28Xc2XEfrooL4IPsf+eTSyB3Y6EmSqnSOPiIhOXW8YogzgNvfUbFnsUKReX3z1F+vfvy2vZ4einL1E5Qkyclk89apvans+0bFvnJHrlfw+6rXsrGLhkjr2f2GopmAA6sHOZqBTvwCEKbtxYfWB3gZl9LMfdWjUJv1VhX3CsieQKPGdzIagZY3GLX3pFX8vk08/8k4ystmmHWetvceKQBfrdZ/NcT25lqtKPtL6Wus4gVcKqhmVXyqElGNirrLK0CeuZ2lGbgkt1h2YDUYhbs0lPu4hv2LfP6wj5Ct3fvfiYCBiGPO5Ql9hGNFUNJJjkmtiaolqbHZ1XbD5ODftMMGUsIZWKnXe97gizbofHEvjIxfcbG+npQZ3yunaMwOzQhfV/Gay4enR08Rq67k2g1A0kCdY/G6hb5kKP5gfvXlp75cqaVeW2p1zbx8nhTYlU84YAHtxm2bMWPXrn/Gesc3jZZzWjGV01YO7qnhn54s5DeSePQIWLNzymxghJ+vCbju0GAmznUJrjwjylRaRpm+yQbkS5RaFaA94hdTLT5PzqjC2H8uVuYAOU=
+    secure: p2iPDFozZji1TiOopmiXiZHiNmPFTRFKzrjiG+wxyPnAJ3BWzCGT1LDYLYnDL2CJY/uk3ZhUuX0QBZLAVaJTdZVMI9IrzD2QOii4VywMFJcA80zh5r7L3ReRYy9yBY1RBh2qR/Lbu9n+Iu4kKcKAfjjNkvBc/WSQo9c7hYGsRgeLYANPuaCW8FpNCWfDODtWaFwXQ7WWOfCYEdABDjthGhtaekN3El2CjQulWrUgMLCs1EQrjO4dm8n9/C840CaLlzsKmb7lNmqSj9oHQBUhmkqfm5VTJqP9Vb12X1AjY/Mu+9BfyUT4jBWAiqxPKJNwzuwNqeqXwc0OlRZaleyWKtIVurUQiXJVjiskOHpkjZ/vyjU/oLFigbiUDgmiCQVNsoJT1l6JjKjOSGuW28PXmDJWZf6MLM1jfh7zUqvQAZJkCr22dc8pEX6SzirxHFs7zdwAgRWxMkIaC7JUnbM+OCh1D+BqwCgmvqYrkBmpaX9/F8AySz5ZJa0Cz/BMUvx7QQOxW21D+BSkggR2ohkDQe2FCrg0iVSKCjD24P28TwncpO17kF+dIt9qF2zS/PTWt8mvwTEg0SsonU3cDM+a3jGak8AK9s6+YZaBdPdlZhyn9TI3Cx3tomha3juJU4wAH8jljzn6RxdTdEvdsqaEkWbzJRB+gKgKBlBFewj0HsQ=
     on_success: change
     on_failure: always
+
+addons:
+  hosts:
+    - travis.dev
+
+env:
+  global:
+    WEB_PATH="/var/www"
+    CFG_API_CUSTOMER_NUMBER="11223344"
+    CFG_API_SHOP_NUMBER="12345"
+    CFG_API_KEY="11111111111111111111"
+    USER1_EMAIL="konstantin.kiritsenko+1@shopgate.com"
+    USER_PASS="test123"
+  matrix:
+    - MAGE_FOLDER="mage_ce_1702" MAGE_PACKAGE="sg-magento-mirror-1.7.0.2" MAGE_TYPE="CE"
+    - MAGE_FOLDER="mage_ce_1810" MAGE_PACKAGE="sg-magento-mirror-1.8.1.0" MAGE_TYPE="CE" MAGE_LOCALE="en_US"
+    - MAGE_FOLDER="mage_ce_1936" MAGE_PACKAGE="magento-mirror-1.9.3.6" MAGE_TYPE="CE"
+    - MAGE_FOLDER="mage_ee_11202" MAGE_PACKAGE="magento-1.12.0.2" MAGE_TYPE="EE" MAGE_LOCALE="en_US"
+    - MAGE_FOLDER="mage_ee_11302" MAGE_PACKAGE="magento-1.13.0.2" MAGE_TYPE="EE"
+    - MAGE_FOLDER="mage_ee_11437" MAGE_PACKAGE="magento-1.14.3.7" MAGE_TYPE="EE"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,18 +10,19 @@ install:
   - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install 8.4
 
 php:
-  - 5.3 #todo-sg: upgrade oAuth extension to v1.11 when it is available
+  - 5.3
   - 5.4
   - 5.5
   - 5.6
 
 before_script:
-  - if [[ "$TRAVIS_TAG" ]] || [ "$TRAVIS_EVENT_TYPE" != "push" ]; then
+  # If it's a fork PR (no secret keys will exist), then run only CE edition tests. And run only on non commit calls.
+  - if [[ ( "$AWS_ACCESS_KEY_ID" || "$MAGE_TYPE" == "CE" ) && ( "$TRAVIS_TAG" || "$TRAVIS_EVENT_TYPE" != "push" ) ]]; then
       chmod +x ./tests/postman/test_env_setup.sh;
       ./tests/postman/test_env_setup.sh;
     fi
 script:
-  - if [[ "$TRAVIS_TAG" ]] || [ "$TRAVIS_EVENT_TYPE" != "push" ]; then
+  - if [[ ( "$AWS_ACCESS_KEY_ID" || "$MAGE_TYPE" == "CE" ) && ( "$TRAVIS_TAG" || "$TRAVIS_EVENT_TYPE" != "push" ) ]]; then
       chmod +x ./tests/postman/magento_setup.sh;
       ./tests/postman/magento_setup.sh;
       cd ${TRAVIS_BUILD_DIR}/tests/postman/newman;

--- a/src/app/code/community/Shopgate/Cloudapi/Model/Acl/Filter.php
+++ b/src/app/code/community/Shopgate/Cloudapi/Model/Acl/Filter.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Copyright Shopgate Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author    Shopgate Inc, 804 Congress Ave, Austin, Texas 78701 <interfaces@shopgate.com>
+ * @copyright Shopgate Inc
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
+ */
+class Shopgate_Cloudapi_Model_Acl_Filter extends Mage_Api2_Model_Acl_Filter
+{
+    /**
+     * @inheritdoc
+     */
+    public function in(array $requestData)
+    {
+        /**
+         * @todo-sg: this will also need to be done for custom options of products
+         */
+        if (isset($requestData['product']['recurring_profile_start_datetime'])) {
+            $date = Mage::app()->getLocale()->date($requestData['product']['recurring_profile_start_datetime']);
+            /** Converting date to locale defined */
+            $requestData['product']['recurring_profile_start_datetime'] = $date->toString();
+        }
+
+        return parent::in($requestData);
+    }
+}

--- a/src/app/code/community/Shopgate/Cloudapi/Model/Api2/Products/Rest.php
+++ b/src/app/code/community/Shopgate/Cloudapi/Model/Api2/Products/Rest.php
@@ -189,32 +189,31 @@ abstract class Shopgate_Cloudapi_Model_Api2_Products_Rest extends Shopgate_Cloud
      * Load product by its SKU or ID provided in request
      *
      * @return Mage_Catalog_Model_Product
+     * @throws Mage_Api2_Exception
+     * @throws Exception
      */
     protected function getProduct()
     {
-        if (is_null($this->product)) {
+        if (null === $this->product) {
             $productId = $this->getRequest()->getParam('id');
             /** @var $productHelper Mage_Catalog_Helper_Product */
             $productHelper = Mage::helper('catalog/product');
             $product       = $productHelper->getProduct($productId, $this->_getStore()->getId());
-            if (!($product->getId())) {
+            if (!$product->getId()) {
                 $this->_critical(self::RESOURCE_NOT_FOUND);
             }
             // check if product belongs to website current
             if ($this->_getStore()->getId()) {
-                $isValidWebsite = in_array($this->_getStore()->getWebsiteId(), $product->getWebsiteIds());
+                $isValidWebsite = in_array($this->_getStore()->getWebsiteId(), $product->getWebsiteIds(), false);
                 if (!$isValidWebsite) {
                     $this->_critical(self::RESOURCE_NOT_FOUND);
                 }
             }
-            // Check display settings for customers & guests
-            if ($this->getApiUser()->getType() != Mage_Api2_Model_Auth_User_Admin::USER_TYPE) {
-                // check if product assigned to any website and can be shown
-                if ((!Mage::app()->isSingleStoreMode() && !count($product->getWebsiteIds()))
-                    || !$productHelper->canShow($product)
-                ) {
-                    $this->_critical(self::RESOURCE_NOT_FOUND);
-                }
+            // check if product assigned to any website and can be shown
+            if (!$productHelper->canShow($product)
+                || (!Mage::app()->isSingleStoreMode() && !count($product->getWebsiteIds()))
+            ) {
+                $this->_critical(self::RESOURCE_NOT_FOUND);
             }
             $this->product = $product;
         }

--- a/src/app/code/community/Shopgate/Cloudapi/Model/Api2/Resource.php
+++ b/src/app/code/community/Shopgate/Cloudapi/Model/Api2/Resource.php
@@ -40,6 +40,9 @@ class Shopgate_Cloudapi_Model_Api2_Resource extends Mage_Api2_Model_Resource
      */
     const FAULT_RESOURCE = '';
 
+    /** @var Shopgate_Cloudapi_Model_Acl_Filter */
+    protected $filter;
+
     /**
      * Hack rewrite of the main dispatch so that we
      * can pass empty POST requests
@@ -153,5 +156,18 @@ class Shopgate_Cloudapi_Model_Api2_Resource extends Mage_Api2_Model_Resource
         $faults   = Mage::getModel('api/config', $path)->getFaults($resource);
 
         return (string)isset($faults[$code]) ? $faults[$code]['message'] : $fallback;
+    }
+
+    /**
+     * @inheritdoc
+     * @return Shopgate_Cloudapi_Model_Acl_Filter
+     */
+    public function getFilter()
+    {
+        if (!$this->filter) {
+            $this->filter = Mage::getModel('shopgate_cloudapi/acl_filter', $this);
+        }
+
+        return $this->filter;
     }
 }

--- a/src/app/code/community/Shopgate/Cloudapi/etc/config.xml
+++ b/src/app/code/community/Shopgate/Cloudapi/etc/config.xml
@@ -91,6 +91,13 @@
                     <frontName>shopgate-checkout</frontName>
                 </args>
             </shopgate_cloudapi_checkout_redirect>
+            <shopgate>
+                <use>standard</use>
+                <args>
+                    <module>Shopgate_Cloudapi</module>
+                    <frontName>shopgate</frontName>
+                </args>
+            </shopgate>
         </routers>
         <events>
             <checkout_onepage_controller_success_action>

--- a/src/lib/Shopgate/cloud-integration-magento-oauth2/composer.json
+++ b/src/lib/Shopgate/cloud-integration-magento-oauth2/composer.json
@@ -12,7 +12,7 @@
   ],
   "require": {
     "php": ">=5.3.9",
-    "bshaffer/oauth2-server-php": "1.9.*",
+    "bshaffer/oauth2-server-php": "1.9.* || ~1.11",
     "roave/security-advisories": "dev-master"
   },
   "require-dev": {

--- a/src/lib/Shopgate/cloud-integration-magento-oauth2/composer.json
+++ b/src/lib/Shopgate/cloud-integration-magento-oauth2/composer.json
@@ -12,7 +12,7 @@
   ],
   "require": {
     "php": ">=5.3.9",
-    "bshaffer/oauth2-server-php": "~1.8",
+    "bshaffer/oauth2-server-php": "1.9.*",
     "roave/security-advisories": "dev-master"
   },
   "require-dev": {

--- a/src/lib/Shopgate/cloud-integration-magento-oauth2/composer.lock
+++ b/src/lib/Shopgate/cloud-integration-magento-oauth2/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "6fd4f5cbf792b45fc26529240122feec",
+    "content-hash": "b9a9370078b9f4ec3c84413d05e29269",
     "packages": [
         {
             "name": "bshaffer/oauth2-server-php",
@@ -68,12 +68,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "497fce9103b12b99e8d166bc466d015f5b07c0d8"
+                "reference": "40b035345ed34a4cc92c842f60a6cc739101542f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/497fce9103b12b99e8d166bc466d015f5b07c0d8",
-                "reference": "497fce9103b12b99e8d166bc466d015f5b07c0d8",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/40b035345ed34a4cc92c842f60a6cc739101542f",
+                "reference": "40b035345ed34a4cc92c842f60a6cc739101542f",
                 "shasum": ""
             },
             "conflict": {
@@ -106,6 +106,7 @@
                 "firebase/php-jwt": "<2",
                 "friendsofsymfony/rest-bundle": ">=1.2,<1.2.2",
                 "friendsofsymfony/user-bundle": ">=1.2,<1.3.5",
+                "gree/jose": "<=2.2",
                 "gregwar/rst": "<1.0.3",
                 "guzzlehttp/guzzle": ">=6,<6.2.1|>=4.0.0-rc2,<4.2.4|>=5,<5.3.1",
                 "illuminate/auth": ">=4,<4.0.99|>=4.1,<4.1.26",
@@ -204,7 +205,7 @@
                 }
             ],
             "description": "Prevents installation of composer packages with known security vulnerabilities: no API, simply require it",
-            "time": "2017-12-05T17:52:25+00:00"
+            "time": "2017-12-12T00:38:43+00:00"
         }
     ],
     "packages-dev": [

--- a/src/lib/Shopgate/cloud-integration-magento-oauth2/composer.lock
+++ b/src/lib/Shopgate/cloud-integration-magento-oauth2/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "eacf531976742a048887e3ee1d0f2f37",
+    "content-hash": "6fd4f5cbf792b45fc26529240122feec",
     "packages": [
         {
             "name": "bshaffer/oauth2-server-php",
-            "version": "v1.10.0",
+            "version": "v1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bshaffer/oauth2-server-php.git",
-                "reference": "d158878425392fe5a0cc34f15dbaf46315ae0ed9"
+                "reference": "8856aed1a98d6da596ae3f9b8095b5c7a1581697"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bshaffer/oauth2-server-php/zipball/d158878425392fe5a0cc34f15dbaf46315ae0ed9",
-                "reference": "d158878425392fe5a0cc34f15dbaf46315ae0ed9",
+                "url": "https://api.github.com/repos/bshaffer/oauth2-server-php/zipball/8856aed1a98d6da596ae3f9b8095b5c7a1581697",
+                "reference": "8856aed1a98d6da596ae3f9b8095b5c7a1581697",
                 "shasum": ""
             },
             "require": {
@@ -27,14 +27,12 @@
                 "aws/aws-sdk-php": "~2.8",
                 "firebase/php-jwt": "~2.2",
                 "mongodb/mongodb": "^1.1",
-                "phpunit/phpunit": "^4.0",
                 "predis/predis": "dev-master",
                 "thobbs/phpcassa": "dev-master"
             },
             "suggest": {
                 "aws/aws-sdk-php": "~2.8 is required to use DynamoDB storage",
-                "firebase/php-jwt": "~2.2 is required to use JWT features",
-                "mongodb/mongodb": "^1.1 is required to use MongoDB storage",
+                "firebase/php-jwt": "~1.1 is required to use MondoDB storage",
                 "predis/predis": "Required to use Redis storage",
                 "thobbs/phpcassa": "Required to use Cassandra storage"
             },
@@ -62,7 +60,7 @@
                 "oauth",
                 "oauth2"
             ],
-            "time": "2017-11-15T01:41:02+00:00"
+            "time": "2017-01-06T23:20:00+00:00"
         },
         {
             "name": "roave/security-advisories",
@@ -70,27 +68,28 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "163addd893dcf9df4ca7b7b42b39ef369d79822f"
+                "reference": "497fce9103b12b99e8d166bc466d015f5b07c0d8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/163addd893dcf9df4ca7b7b42b39ef369d79822f",
-                "reference": "163addd893dcf9df4ca7b7b42b39ef369d79822f",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/497fce9103b12b99e8d166bc466d015f5b07c0d8",
+                "reference": "497fce9103b12b99e8d166bc466d015f5b07c0d8",
                 "shasum": ""
             },
             "conflict": {
                 "adodb/adodb-php": "<5.20.6",
-                "amphp/artax": ">=2,<2.0.6|<1.0.6",
+                "amphp/artax": "<1.0.6|>=2,<2.0.6",
                 "aws/aws-sdk-php": ">=3,<3.2.1",
                 "bugsnag/bugsnag-laravel": ">=2,<2.0.2",
-                "cakephp/cakephp": ">=2,<2.4.99|>=2.5,<2.5.99|>=2.6,<2.6.12|>=2.7,<2.7.6|>=3,<3.0.15|>=3.1,<3.1.4|>=1.3,<1.3.18",
+                "cakephp/cakephp": ">=1.3,<1.3.18|>=2,<2.4.99|>=2.5,<2.5.99|>=2.6,<2.6.12|>=2.7,<2.7.6|>=3,<3.0.15|>=3.1,<3.1.4",
                 "cart2quote/module-quotation": ">=4.1.6,<=4.4.5|>=5,<5.4.4",
-                "cartalyst/sentry": "<2.1",
+                "cartalyst/sentry": "<=2.1.6",
                 "codeigniter/framework": "<=3.0.6",
                 "composer/composer": "<=1.0.0-alpha11",
                 "contao-components/mediaelement": ">=2.14.2,<2.21.1",
-                "contao/core": ">=2,<3.5.28",
-                "contao/core-bundle": ">=4,<4.4.1",
+                "contao/core": ">=2,<3.5.31",
+                "contao/core-bundle": ">=4,<4.4.8",
+                "contao/listing-bundle": ">=4,<4.4.8",
                 "doctrine/annotations": ">=1,<1.2.7",
                 "doctrine/cache": ">=1,<1.3.2|>=1.4,<1.4.2",
                 "doctrine/common": ">=2,<2.4.3|>=2.5,<2.5.1",
@@ -103,7 +102,7 @@
                 "dompdf/dompdf": ">=0.6,<0.6.2",
                 "drupal/core": ">=8,<8.3.7",
                 "drupal/drupal": ">=8,<8.3.7",
-                "ezsystems/ezpublish-legacy": ">=5.4,<5.4.10.1|>=5.3,<5.3.12.2|>=2017.8,<2017.8.1.1",
+                "ezsystems/ezpublish-legacy": ">=5.3,<5.3.12.2|>=5.4,<5.4.10.1|>=2017.8,<2017.8.1.1",
                 "firebase/php-jwt": "<2",
                 "friendsofsymfony/rest-bundle": ">=1.2,<1.2.2",
                 "friendsofsymfony/user-bundle": ">=1.2,<1.3.5",
@@ -123,7 +122,7 @@
                 "oro/crm": ">=1.7,<1.7.4",
                 "oro/platform": ">=1.7,<1.7.4",
                 "phpmailer/phpmailer": ">=5,<5.2.24",
-                "phpunit/phpunit": ">=5.0.10,<5.6.3|>=4.8.19,<4.8.28",
+                "phpunit/phpunit": ">=4.8.19,<4.8.28|>=5.0.10,<5.6.3",
                 "phpxmlrpc/extras": "<6.0.1",
                 "pusher/pusher-php-server": "<2.2.1",
                 "sabre/dav": ">=1.6,<1.6.99|>=1.7,<1.7.11|>=1.8,<1.8.9",
@@ -139,16 +138,18 @@
                 "squizlabs/php_codesniffer": ">=1,<2.8.1",
                 "swiftmailer/swiftmailer": ">=4,<5.4.5",
                 "symfony/dependency-injection": ">=2,<2.0.17",
-                "symfony/form": ">=2.3,<2.3.35|>=2.4,<2.6.12|>=2.7,<2.7.7",
+                "symfony/form": ">=2.3,<2.3.35|>=2.4,<2.6.12|>=2.7,<2.7.38|>=2.8,<2.8.31|>=3,<3.2.14|>=3.3,<3.3.13",
                 "symfony/framework-bundle": ">=2,<2.3.18|>=2.4,<2.4.8|>=2.5,<2.5.2",
                 "symfony/http-foundation": ">=2,<2.3.27|>=2.4,<2.5.11|>=2.6,<2.6.6",
                 "symfony/http-kernel": ">=2,<2.3.29|>=2.4,<2.5.12|>=2.6,<2.6.8",
+                "symfony/intl": ">=2.7,<2.7.38|>=2.8,<2.8.31|>=3,<3.2.14|>=3.3,<3.3.13",
                 "symfony/routing": ">=2,<2.0.19",
-                "symfony/security": ">=2.3,<2.3.37|>=2.4,<2.6.13|>=2.7,<2.7.9|>=2.7.30,<2.7.32|>=2.8.23,<2.8.25|>=3.2.10,<3.2.12|>=3.3.3,<3.3.5|>=2,<2.0.25|>=2.1,<2.1.13|>=2.2,<2.2.9",
-                "symfony/security-core": ">=2.7.30,<2.7.32|>=2.8.23,<2.8.25|>=3.2.10,<3.2.12|>=3.3.3,<3.3.5|>=2.8,<2.8.6|>=3,<3.0.6|>=2.4,<2.6.13|>=2.7,<2.7.9",
-                "symfony/security-http": ">=2.4,<2.7.13|>=2.3,<2.3.41|>=2.8,<2.8.6|>=3,<3.0.6",
+                "symfony/security": ">=2,<2.0.25|>=2.1,<2.1.13|>=2.2,<2.2.9|>=2.3,<2.3.37|>=2.4,<2.6.13|>=2.7,<2.7.9|>=2.7.30,<2.7.32|>=2.8.23,<2.8.25|>=3.2.10,<3.2.12|>=3.3.3,<3.3.5",
+                "symfony/security-core": ">=2.4,<2.6.13|>=2.7,<2.7.9|>=2.7.30,<2.7.32|>=2.8,<2.8.6|>=2.8.23,<2.8.25|>=3,<3.0.6|>=3.2.10,<3.2.12|>=3.3.3,<3.3.5",
+                "symfony/security-csrf": ">=2.7,<2.7.38|>=2.8,<2.8.31|>=3,<3.2.14|>=3.3,<3.3.13",
+                "symfony/security-http": ">=2.3,<2.3.41|>=2.4,<2.7.38|>=2.8,<2.8.31|>=3,<3.2.14|>=3.3,<3.3.13",
                 "symfony/serializer": ">=2,<2.0.11",
-                "symfony/symfony": ">=2,<2.3.41|>=2.4,<2.7.13|>=2.7.30,<2.7.32|>=2.8.23,<2.8.25|>=3.2.10,<3.2.12|>=3.3.3,<3.3.5|>=2.8,<2.8.6|>=3,<3.0.6",
+                "symfony/symfony": ">=2,<2.3.41|>=2.4,<2.7.38|>=2.8,<2.8.31|>=3,<3.2.14|>=3.3,<3.3.13",
                 "symfony/translation": ">=2,<2.0.17",
                 "symfony/validator": ">=2,<2.0.24|>=2.1,<2.1.12|>=2.2,<2.2.5|>=2.3,<2.3.3",
                 "symfony/web-profiler-bundle": ">=2,<2.3.19|>=2.4,<2.4.9|>=2.5,<2.5.4",
@@ -157,8 +158,8 @@
                 "thelia/thelia": ">=2.1,<2.1.2|>=2.1.0-beta1,<2.1.3",
                 "twig/twig": "<1.20",
                 "typo3/cms": ">=6.2,<6.2.30|>=7,<7.6.22|>=8,<8.7.5",
-                "typo3/flow": ">=2.3,<2.3.16|>=3,<3.0.10|>=1,<1.0.4|>=3.1,<3.1.7|>=3.2,<3.2.7|>=3.3,<3.3.5|>=1.1,<1.1.1|>=2,<2.0.1",
-                "typo3/neos": ">=1.2,<1.2.13|>=2,<2.0.4|>=1.1,<1.1.3",
+                "typo3/flow": ">=1,<1.0.4|>=1.1,<1.1.1|>=2,<2.0.1|>=2.3,<2.3.16|>=3,<3.0.10|>=3.1,<3.1.7|>=3.2,<3.2.7|>=3.3,<3.3.5",
+                "typo3/neos": ">=1.1,<1.1.3|>=1.2,<1.2.13|>=2,<2.0.4",
                 "willdurand/js-translation-bundle": "<2.1.1",
                 "yiisoft/yii": ">=1.1.14,<1.1.15",
                 "yiisoft/yii2": "<2.0.5",
@@ -203,7 +204,7 @@
                 }
             ],
             "description": "Prevents installation of composer packages with known security vulnerabilities: no API, simply require it",
-            "time": "2017-11-17T06:17:27+00:00"
+            "time": "2017-12-05T17:52:25+00:00"
         }
     ],
     "packages-dev": [
@@ -262,135 +263,38 @@
             "time": "2015-06-14T21:17:01+00:00"
         },
         {
-            "name": "phpdocumentor/reflection-common",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
-                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.6"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jaap van Otterdijk",
-                    "email": "opensource@ijaap.nl"
-                }
-            ],
-            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
-            "homepage": "http://www.phpdoc.org",
-            "keywords": [
-                "FQSEN",
-                "phpDocumentor",
-                "phpdoc",
-                "reflection",
-                "static analysis"
-            ],
-            "time": "2017-09-11T18:02:19+00:00"
-        },
-        {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "3.2.2",
+            "version": "2.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "4aada1f93c72c35e22fb1383b47fee43b8f1d157"
+                "reference": "e6a969a640b00d8daa3c66518b0405fb41ae0c4b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/4aada1f93c72c35e22fb1383b47fee43b8f1d157",
-                "reference": "4aada1f93c72c35e22fb1383b47fee43b8f1d157",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/e6a969a640b00d8daa3c66518b0405fb41ae0c4b",
+                "reference": "e6a969a640b00d8daa3c66518b0405fb41ae0c4b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5",
-                "phpdocumentor/reflection-common": "^1.0@dev",
-                "phpdocumentor/type-resolver": "^0.3.0",
-                "webmozart/assert": "^1.0"
+                "php": ">=5.3.3"
             },
             "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^4.4"
+                "phpunit/phpunit": "~4.0"
             },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
-                }
-            ],
-            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-08-08T06:39:58+00:00"
-        },
-        {
-            "name": "phpdocumentor/type-resolver",
-            "version": "0.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "fb3933512008d8162b3cdf9e18dba9309b7c3773"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/fb3933512008d8162b3cdf9e18dba9309b7c3773",
-                "reference": "fb3933512008d8162b3cdf9e18dba9309b7c3773",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.5 || ^7.0",
-                "phpdocumentor/reflection-common": "^1.0"
-            },
-            "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^5.2||^4.8.24"
+            "suggest": {
+                "dflydev/markdown": "~1.0",
+                "erusev/parsedown": "~1.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
+                "psr-0": {
+                    "phpDocumentor": [
                         "src/"
                     ]
                 }
@@ -402,23 +306,23 @@
             "authors": [
                 {
                     "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
+                    "email": "mike.vanriel@naenius.com"
                 }
             ],
-            "time": "2017-06-03T08:32:36+00:00"
+            "time": "2016-01-25T08:17:30+00:00"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.7.2",
+            "version": "1.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6"
+                "reference": "e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6",
-                "reference": "c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf",
+                "reference": "e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf",
                 "shasum": ""
             },
             "require": {
@@ -430,7 +334,7 @@
             },
             "require-dev": {
                 "phpspec/phpspec": "^2.5|^3.2",
-                "phpunit/phpunit": "^4.8 || ^5.6.5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7"
             },
             "type": "library",
             "extra": {
@@ -468,7 +372,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2017-09-04T11:05:03+00:00"
+            "time": "2017-11-24T13:59:53+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -534,16 +438,16 @@
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.2",
+            "version": "1.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5"
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
-                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
                 "shasum": ""
             },
             "require": {
@@ -577,7 +481,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2016-10-03T07:40:28+00:00"
+            "time": "2017-11-27T13:52:08+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -671,16 +575,16 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.11",
+            "version": "1.4.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "e03f8f67534427a787e21a385a67ec3ca6978ea7"
+                "reference": "1ce90ba27c42e4e44e6d8458241466380b51fa16"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/e03f8f67534427a787e21a385a67ec3ca6978ea7",
-                "reference": "e03f8f67534427a787e21a385a67ec3ca6978ea7",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/1ce90ba27c42e4e44e6d8458241466380b51fa16",
+                "reference": "1ce90ba27c42e4e44e6d8458241466380b51fa16",
                 "shasum": ""
             },
             "require": {
@@ -716,7 +620,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-02-27T10:12:30+00:00"
+            "time": "2017-12-04T08:55:13+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -1220,31 +1124,25 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.3.13",
+            "version": "v2.8.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "0938408c4faa518d95230deabb5f595bf0de31b9"
+                "reference": "968ef42161e4bc04200119da473077f9e7015128"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/0938408c4faa518d95230deabb5f595bf0de31b9",
-                "reference": "0938408c4faa518d95230deabb5f595bf0de31b9",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/968ef42161e4bc04200119da473077f9e7015128",
+                "reference": "968ef42161e4bc04200119da473077f9e7015128",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8"
-            },
-            "require-dev": {
-                "symfony/console": "~2.8|~3.0"
-            },
-            "suggest": {
-                "symfony/console": "For validating YAML files using the lint command"
+                "php": ">=5.3.9"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
@@ -1271,57 +1169,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2017-11-10T18:26:04+00:00"
-        },
-        {
-            "name": "webmozart/assert",
-            "version": "1.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.3 || ^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.6",
-                "sebastian/version": "^1.0.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.3-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Webmozart\\Assert\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
-                }
-            ],
-            "description": "Assertions to validate method input/output with nice error messages.",
-            "keywords": [
-                "assert",
-                "check",
-                "validate"
-            ],
-            "time": "2016-11-23T20:04:58+00:00"
+            "time": "2017-11-29T09:33:18+00:00"
         }
     ],
     "aliases": [],

--- a/tests/postman/.n98-magerun.yaml
+++ b/tests/postman/.n98-magerun.yaml
@@ -1,0 +1,34 @@
+commands:
+  N98\Magento\Command\Installer\InstallCommand:
+    magento-packages:
+      - name: sg-magento-mirror-1.8.1.0
+        version: 1.8.1.0
+        dist:
+          url: https://github.com/OpenMage/magento-mirror/archive/1.8.1.0.zip
+          type: zip
+          shasum: 3fbff399799177e8048cc4048f66213fedd132c1
+        extra:
+          sample-data: sample-data-1.9.1.0
+
+      - name: sg-magento-mirror-1.8.0.0
+        version: 1.7.0.2
+        dist:
+          url: https://github.com/OpenMage/magento-mirror/archive/1.8.0.0.zip
+          type: zip
+          shasum: 9b1dee54d0b047b66d7ad6b8ea1ff414b7773093
+        extra:
+          sample-data: sample-data-1.9.1.0
+
+      - name: sg-magento-mirror-1.7.0.2
+        version: 1.7.0.2
+        dist:
+          url: https://github.com/OpenMage/magento-mirror/archive/1.7.0.2.zip
+          type: zip
+          shasum: e7f761d1ca60d16db867e24b5219de8815d0ea25
+        extra:
+          sample-data: sample-data-1.9.1.0
+
+    installation:
+        defaults:
+          currency: EUR
+          locale: de_DE

--- a/tests/postman/magento_setup.sh
+++ b/tests/postman/magento_setup.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -e
+cd ${WEB_PATH}
+
+DOWNLOAD=""
+PARAM2=""
+if [[ ${MAGE_TYPE} == "EE" ]]; then
+	~/.local/bin/aws s3api get-object --bucket shopgate-ci --key magento/magento-shoppingsystem-files.tar.gz magento.tar.gz > /dev/null 2>&1
+	tar -xzf magento.tar.gz ./
+	tar -xzf ./package/ee/${MAGE_PACKAGE}.tar.gz -C ./
+	mv ./${MAGE_PACKAGE} ./${MAGE_FOLDER}
+	# sample data related
+	mkdir ./sample
+	tar -xzf ./package/ee/data/magento-sample-data-1.14.2.4.tar.gz -C ./sample
+	rsync -a ./sample/magento-sample-data-1.14.2.4/ ./${MAGE_FOLDER}
+	mysql -e "CREATE database ${MAGE_FOLDER};"
+	mysql ${MAGE_FOLDER} < ./${MAGE_FOLDER}/magento_sample_data_for_1.14.2.4.sql
+	DOWNLOAD="--noDownload"
+	PARAM2="--forceUseDb"
+	MAGE_PACKAGE="magento-mirror-1.9.3.6" # package needs to exist for n98 to accept install
+fi
+
+n98 script:repo:run n98-setup \
+-d folder=${MAGE_FOLDER} \
+-d package=${MAGE_PACKAGE} \
+-d api_key=${CFG_API_KEY} \
+-d shop_number=${CFG_API_SHOP_NUMBER} \
+-d customer_number=${CFG_API_CUSTOMER_NUMBER} \
+-d user1_email=${USER1_EMAIL} \
+-d user_pass=${USER_PASS} \
+-d misc_param1=${DOWNLOAD} \
+-d misc_param2=${PARAM2} > /dev/null 2>&1
+
+# Adds support to versions < CE1.9.* && < EE1.14.*
+mysql ${MAGE_FOLDER} -e "DELETE FROM eav_attribute WHERE backend_model='catalog/product_attribute_backend_startdate_specialprice';"
+mysql ${MAGE_FOLDER} -e "DELETE FROM eav_attribute WHERE backend_model='enterprise_catalog/product_attribute_backend_urlkey';"
+
+sudo chmod 777 -R ${MAGE_FOLDER}/var
+
+# return back
+cd ${TRAVIS_BUILD_DIR}

--- a/tests/postman/n98-scripts/n98-setup.magerun
+++ b/tests/postman/n98-scripts/n98-setup.magerun
@@ -1,0 +1,22 @@
+#!/usr/bin/env magento installation script
+
+install --dbHost="localhost" --dbUser="root" --dbPass="" --dbName="${folder}" --installSampleData=yes --useDefaultConfigParams=yes --magentoVersionByName="${package}" --installationFolder="${folder}" --baseUrl="http://travis.dev/${folder}/" --no-interaction ${misc_param1} ${misc_param2}
+# in magento folder right now
+
+config:set --scope="websites" --scope-id="1" "shopgate_cloudapi/authentication/customer_number" ${customer_number}
+config:set --scope="websites" --scope-id="1" "shopgate_cloudapi/authentication/shop_number" ${shop_number}
+config:set --scope="websites" --scope-id="1" "shopgate_cloudapi/authentication/api_key" ${api_key}
+
+# creates in General group by default, no good way to set up without using php scripts
+customer:create ${user1_email} ${user_pass} "Test1" "Mock1" "1"
+
+# add cloud api plugin to magento structure
+! rsync -a ${TRAVIS_BUILD_DIR}/src/ ${WEB_PATH}/${folder} > /dev/null
+! echo "SetEnv MAGE_IS_DEVELOPER_MODE true" >> .htaccess
+
+# flush cache and get out of folder to preserve state
+cache:clean
+# install all resources
+sys:setup:run
+cache:clean
+! cd ..

--- a/tests/postman/newman/collection.json
+++ b/tests/postman/newman/collection.json
@@ -1,0 +1,14538 @@
+{
+  "info": {
+    "name": "Mage Cloud",
+    "_postman_id": "0adc460a-cb9e-6b00-ca9a-f4da3f8c2003",
+    "description": "",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "oAuth2",
+      "description": "",
+      "item": [
+        {
+          "name": "Token: client_credentials",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (responseCode.code === 200) {",
+                  "    var jsonData = pm.response.json();",
+                  "    pm.environment.set(\"guest-access-token\", jsonData.access_token);",
+                  "}",
+                  "",
+                  "pm.test('Successfull call', function(){",
+                  "    pm.response.to.be.success;",
+                  "});",
+                  "",
+                  "pm.test(\"Response follows the correct json oAuth2 specifications\", function () {",
+                  "    var jsonData = pm.response.json();",
+                  "    pm.response.to.have.jsonBody('token_type','Bearer');",
+                  "    pm.response.to.have.jsonBody('expires_in', 3600);",
+                  "    pm.response.to.have.jsonBody('access_token');",
+                  "    pm.response.to.have.jsonBody('scope', null);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "PHP_AUTH_USER",
+                "value": "{{client_id}}"
+              },
+              {
+                "key": "PHP_AUTH_PW",
+                "value": "{{client_secret}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"grant_type\": \"client_credentials\",\n  \"client_id\": \"{{client_id}}\",\n  \"client_secret\":\"{{client_secret}}\"\n}"
+            },
+            "url": {
+              "raw": "{{domain}}{{endpoint_auth_token}}",
+              "host": [
+                "{{domain}}{{endpoint_auth_token}}"
+              ]
+            },
+            "description": ""
+          },
+          "response": []
+        },
+        {
+          "name": "Token: password",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (responseCode.code === 200) {",
+                  "    var jsonData = pm.response.json();",
+                  "    pm.environment.set(\"refresh-token\", jsonData.refresh_token);",
+                  "    pm.environment.set(\"customer-access-token\", jsonData.access_token);",
+                  "}",
+                  "",
+                  "pm.test('Successfull call', function(){",
+                  "    pm.response.to.be.success;",
+                  "});",
+                  "",
+                  "pm.test(\"Response follows the correct json oAuth2 specifications\", function () {",
+                  "    var jsonData = pm.response.json();",
+                  "    pm.response.to.have.jsonBody('token_type','Bearer');",
+                  "    pm.response.to.have.jsonBody('expires_in', 3600);",
+                  "    pm.response.to.have.jsonBody('refresh_token');",
+                  "    pm.response.to.have.jsonBody('access_token');",
+                  "    pm.response.to.have.jsonBody('scope', null);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "PHP_AUTH_USER",
+                "value": "{{client_id}}"
+              },
+              {
+                "key": "PHP_AUTH_PW",
+                "value": "{{client_secret}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"grant_type\": \"password\",\n  \"username\": \"{{username}}\",\n  \"password\": \"{{password}}\",\n  \"client_id\": \"{{client_id}}\",\n  \"client_secret\":\"{{client_secret}}\"\n}"
+            },
+            "url": {
+              "raw": "{{domain}}{{endpoint_auth_token}}",
+              "host": [
+                "{{domain}}{{endpoint_auth_token}}"
+              ]
+            },
+            "description": ""
+          },
+          "response": []
+        },
+        {
+          "name": "Token: authorization_code",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "id": "e455c6e7-0555-4b6e-a1e9-e4df1e547257",
+                "type": "text/javascript",
+                "exec": [
+                  "if (false) { //skip for now as there is no good way to test",
+                  "    if (responseCode.code === 200) {",
+                  "        var jsonData = pm.response.json();",
+                  "        pm.environment.set(\"guest-access-token\", jsonData.access_token);",
+                  "    }",
+                  "    ",
+                  "    pm.test('Successfull call', function(){",
+                  "        pm.response.to.be.success;",
+                  "    });",
+                  "    ",
+                  "    pm.test(\"Response follows the correct json oAuth2 specifications\", function () {",
+                  "        var jsonData = pm.response.json();",
+                  "        pm.response.to.have.jsonBody('token_type','Bearer');",
+                  "        pm.response.to.have.jsonBody('expires_in', 3600);",
+                  "        pm.response.to.have.jsonBody('access_token');",
+                  "        pm.response.to.have.jsonBody('scope', null);",
+                  "    });",
+                  "}",
+                  ""
+                ]
+              }
+            },
+            {
+              "listen": "prerequest",
+              "script": {
+                "id": "3092705d-cd39-4811-b8df-1c6636d785a4",
+                "type": "text/javascript",
+                "exec": [
+                  ""
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "PHP_AUTH_USER",
+                "value": "{{client_id}}"
+              },
+              {
+                "key": "PHP_AUTH_PW",
+                "value": "{{client_secret}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"grant_type\": \"authorization_code\",\n  \"code\": \"a946748ca6f9d99d09abb3b6350ee98e5e45121e\"\n}"
+            },
+            "url": {
+              "raw": "{{domain}}{{endpoint_auth_token}}",
+              "host": [
+                "{{domain}}{{endpoint_auth_token}}"
+              ]
+            },
+            "description": ""
+          },
+          "response": []
+        },
+        {
+          "name": "Token: refresh_token",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (responseCode.code === 200) {",
+                  "    var jsonData = pm.response.json();",
+                  "    pm.environment.set(\"customer-access-token\", jsonData.access_token);",
+                  "}",
+                  "",
+                  "pm.test('Successfull call', function(){",
+                  "    pm.response.to.be.success;",
+                  "});",
+                  "",
+                  "pm.test(\"Response follows the correct json oAuth2 specifications\", function () {",
+                  "    var jsonData = pm.response.json();",
+                  "    pm.response.to.have.jsonBody('token_type','Bearer');",
+                  "    pm.response.to.have.jsonBody('expires_in', 3600);",
+                  "    pm.response.to.have.jsonBody('refresh_token');",
+                  "    pm.response.to.have.jsonBody('access_token');",
+                  "    pm.response.to.have.jsonBody('scope', null);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "PHP_AUTH_USER",
+                "value": "{{client_id}}"
+              },
+              {
+                "key": "PHP_AUTH_PW",
+                "value": "{{client_secret}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"grant_type\": \"refresh_token\",\n  \"refresh_token\": \"{{refresh-token}}\",\n  \"client_id\": \"{{client_id}}\",\n  \"client_secret\":\"{{client_secret}}\"\n}"
+            },
+            "url": {
+              "raw": "{{domain}}{{endpoint_auth_token}}",
+              "host": [
+                "{{domain}}{{endpoint_auth_token}}"
+              ]
+            },
+            "description": ""
+          },
+          "response": []
+        },
+        {
+          "name": "Token: refresh_token re-use",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "tests[\"Status code is 400\"] = responseCode.code === 400;"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "PHP_AUTH_USER",
+                "value": "{{client_id}}"
+              },
+              {
+                "key": "PHP_AUTH_PW",
+                "value": "{{client_secret}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"grant_type\": \"refresh_token\",\n  \"refresh_token\": \"{{refresh-token}}\",\n  \"client_id\": \"{{client_id}}\",\n  \"client_secret\":\"{{client_secret}}\"\n}"
+            },
+            "url": {
+              "raw": "{{domain}}{{endpoint_auth_token}}",
+              "host": [
+                "{{domain}}{{endpoint_auth_token}}"
+              ]
+            },
+            "description": ""
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "/v2/carts | /v2/carts/:id",
+      "description": "",
+      "item": [
+        {
+          "name": "Customer",
+          "description": "",
+          "item": [
+            {
+              "name": "Create customer cart",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "var jsonData = pm.response.json();",
+                      "if (responseCode.code === 200 && jsonData.hasOwnProperty('cartId')) {",
+                      "    pm.environment.set(\"cartId\", jsonData.cartId);",
+                      "    tests[\"Cart ID is returned\"] = isNumeric(jsonData.cartId) === true;",
+                      "} else {",
+                      "    tests[\"Cart ID is not returned\"] = false;",
+                      "}",
+                      "",
+                      "pm.test('Successfull call', function(){",
+                      "    pm.response.to.be.success;",
+                      "});",
+                      "",
+                      "function isNumeric(n) {",
+                      "  return !isNaN(parseFloat(n)) && isFinite(n);",
+                      "}"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{customer-access-token}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{}"
+                },
+                "url": {
+                  "raw": "{{domain}}{{endpoint_carts}}",
+                  "host": [
+                    "{{domain}}{{endpoint_carts}}"
+                  ]
+                },
+                "description": "Creates a customer cart"
+              },
+              "response": []
+            },
+            {
+              "name": "Get Cart via ME endpoint",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Successfully loaded cart via ME endpoint\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{customer-access-token}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{}"
+                },
+                "url": {
+                  "raw": "{{domain}}{{endpoint_carts}}/me",
+                  "host": [
+                    "{{domain}}{{endpoint_carts}}"
+                  ],
+                  "path": [
+                    "me"
+                  ]
+                },
+                "description": "Creates a customer cart"
+              },
+              "response": []
+            },
+            {
+              "name": "Get cart via {cartId}",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{customer-access-token}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{}"
+                },
+                "url": {
+                  "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                  "host": [
+                    "{{domain}}{{endpoint_carts}}"
+                  ],
+                  "path": [
+                    "{{cartId}}"
+                  ]
+                },
+                "description": ""
+              },
+              "response": []
+            },
+            {
+              "name": "Use bad cartID",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Bogus quote cannot be found\", function () {",
+                      "    pm.response.to.have.status(404);",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{customer-access-token}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{}"
+                },
+                "url": {
+                  "raw": "{{domain}}{{endpoint_carts}}/000",
+                  "host": [
+                    "{{domain}}{{endpoint_carts}}"
+                  ],
+                  "path": [
+                    "000"
+                  ]
+                },
+                "description": ""
+              },
+              "response": []
+            }
+          ],
+          "_postman_isSubFolder": true
+        },
+        {
+          "name": "Guest",
+          "description": "",
+          "item": [
+            {
+              "name": "ME endpoint as guest",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "tests[\"loading ME endpoint as guest fails\"] = responseCode.code === 400;"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{guest-access-token}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{}"
+                },
+                "url": {
+                  "raw": "{{domain}}{{endpoint_carts}}/me",
+                  "host": [
+                    "{{domain}}{{endpoint_carts}}"
+                  ],
+                  "path": [
+                    "me"
+                  ]
+                },
+                "description": "calls a ME endpoint"
+              },
+              "response": []
+            },
+            {
+              "name": "Customer Quote as guest",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status code is 403\", function () {",
+                      "    pm.response.to.have.status(403);",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{guest-access-token}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{}"
+                },
+                "url": {
+                  "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                  "host": [
+                    "{{domain}}{{endpoint_carts}}"
+                  ],
+                  "path": [
+                    "{{cartId}}"
+                  ]
+                },
+                "description": "calls a customer cart as guest"
+              },
+              "response": []
+            },
+            {
+              "name": "Create guest cart",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "var jsonData = pm.response.json();",
+                      "if (responseCode.code === 200 && jsonData.hasOwnProperty('cartId')) {",
+                      "    pm.environment.set(\"cartId\", jsonData.cartId);",
+                      "    tests[\"Cart ID is returned\"] = isNumeric(jsonData.cartId) === true;",
+                      "} else {",
+                      "    tests[\"Cart ID is not returned\"] = false;",
+                      "}",
+                      "",
+                      "pm.test('Successfull call', function(){",
+                      "    pm.response.to.be.success;",
+                      "});",
+                      "",
+                      "function isNumeric(n) {",
+                      "  return !isNaN(parseFloat(n)) && isFinite(n);",
+                      "}"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{guest-access-token}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{}"
+                },
+                "url": {
+                  "raw": "{{domain}}{{endpoint_carts}}",
+                  "host": [
+                    "{{domain}}{{endpoint_carts}}"
+                  ]
+                },
+                "description": "Creates a guest cart and assigns the local cartId variable from the one returned"
+              },
+              "response": []
+            },
+            {
+              "name": "Guest Quote as guest",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "tests[\"Loading guest quote as guest\"] = responseCode.code === 200;"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{guest-access-token}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{}"
+                },
+                "url": {
+                  "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                  "host": [
+                    "{{domain}}{{endpoint_carts}}"
+                  ],
+                  "path": [
+                    "{{cartId}}"
+                  ]
+                },
+                "description": ""
+              },
+              "response": []
+            }
+          ],
+          "_postman_isSubFolder": true
+        }
+      ]
+    },
+    {
+      "name": "/v2/carts/:id/items",
+      "description": "",
+      "item": [
+        {
+          "name": "Product",
+          "description": "",
+          "item": [
+            {
+              "name": "Customer - Add",
+              "description": "",
+              "item": [
+                {
+                  "name": "/carts: customer",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "var jsonData = pm.response.json();",
+                          "if (responseCode.code === 200 && jsonData.hasOwnProperty('cartId')) {",
+                          "    pm.environment.set(\"cartId\", jsonData.cartId);",
+                          "    tests[\"Cart ID is returned\"] = isNumeric(jsonData.cartId) === true;",
+                          "} else {",
+                          "    tests[\"Cart ID is not returned\"] = false;",
+                          "}",
+                          "",
+                          "pm.test('Successfull call', function(){",
+                          "    pm.response.to.be.success;",
+                          "});",
+                          "",
+                          "function isNumeric(n) {",
+                          "  return !isNaN(parseFloat(n)) && isFinite(n);",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "bearer",
+                      "bearer": [
+                        {
+                          "key": "token",
+                          "value": "{{customer-access-token}}",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{}"
+                    },
+                    "url": {
+                      "raw": "{{domain}}{{endpoint_carts}}",
+                      "host": [
+                        "{{domain}}{{endpoint_carts}}"
+                      ]
+                    },
+                    "description": "Creates a customer cart"
+                  },
+                  "response": []
+                },
+                {
+                  "name": "Bundle + Configurable",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Successfull call', function(){",
+                          "    pm.response.to.be.success;",
+                          "});"
+                        ]
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "bearer",
+                      "bearer": [
+                        {
+                          "key": "token",
+                          "value": "{{customer-access-token}}",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "[\n  {\n    \"product\": {\n      \"product_id\": \"447\",\n      \"qty\": 2,\n      \"bundle_option\": {\n        \"23\": \"88\",\n        \"24\": \"91\"\n      },\n      \"bundle_option_qty\": {\n        \"23\": \"3\",\n        \"24\": \"4\"\n      }\n    }\n  },\n  {\n    \"product\": {\n       \"product_id\": \"422\",\n    \t\"qty\": 1,\n    \t\"super_attribute\": {\n           \"92\": \"17\",\n           \"180\": \"76\"\n        }\n    }\n  }\n]"
+                    },
+                    "url": {
+                      "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                      "host": [
+                        "{{domain}}{{endpoint_carts_id_items}}"
+                      ]
+                    },
+                    "description": ""
+                  },
+                  "response": []
+                },
+                {
+                  "name": "Add Configurable: Skirt",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Successfull call', function(){",
+                          "    pm.response.to.be.success;",
+                          "});"
+                        ]
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "bearer",
+                      "bearer": [
+                        {
+                          "key": "token",
+                          "value": "{{customer-access-token}}",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "[\n  {\n\t    \"product\": {\n\t\t    \"product_id\": \"422\",\n\t\t    \"qty\": 1,\n\t\t    \"super_attribute\": {\n\t\t\t      \"92\": \"17\",\n\t\t\t      \"180\": \"76\"\n\t\t\t    }\n\t\t}\n  }\n]"
+                    },
+                    "url": {
+                      "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                      "host": [
+                        "{{domain}}{{endpoint_carts_id_items}}"
+                      ]
+                    },
+                    "description": "ID: 422\nType: Configurable\nName: Essex Pencil Skirt\nSKU: wsd000c\nCategory: Dresses & Skirts\nPrice: $185.00\n\nSub-Products:\nID: 297 | 298 | 299 | 300 | 301\nName: Essex Pencil Skirt\nSKU: wsd000 | wsd001 | wsd002 | wsd003 | wsd004\nColor (ID: 92): Charcoal (ID: 17)\nSize (ID: 180): 2 (ID: 76) | 4 (ID: 75) | 6 (ID: 74) | 8 (ID: 73) | 10 (ID: 72)"
+                  },
+                  "response": []
+                },
+                {
+                  "name": "Add Configurable: Skirt via SKU",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Successfull call', function(){",
+                          "    pm.response.to.be.success;",
+                          "});"
+                        ]
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "bearer",
+                      "bearer": [
+                        {
+                          "key": "token",
+                          "value": "{{customer-access-token}}",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "[\n  {\n\t    \"product\": {\n\t\t    \"sku\": \"wsd000c\",\n\t\t    \"qty\": 1,\n\t\t    \"super_attribute\": {\n\t\t\t      \"92\": \"17\",\n\t\t\t      \"180\": \"76\"\n\t\t\t    }\n\t\t}\n  }\n]"
+                    },
+                    "url": {
+                      "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                      "host": [
+                        "{{domain}}{{endpoint_carts_id_items}}"
+                      ]
+                    },
+                    "description": "ID: 422\nType: Configurable\nName: Essex Pencil Skirt\nSKU: wsd000c\nCategory: Dresses & Skirts\nPrice: $185.00\n\nSub-Products:\nID: 297 | 298 | 299 | 300 | 301\nName: Essex Pencil Skirt\nSKU: wsd000 | wsd001 | wsd002 | wsd003 | wsd004\nColor (ID: 92): Charcoal (ID: 17)\nSize (ID: 180): 2 (ID: 76) | 4 (ID: 75) | 6 (ID: 74) | 8 (ID: 73) | 10 (ID: 72)"
+                  },
+                  "response": []
+                },
+                {
+                  "name": "Bundled",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Successfull call', function(){",
+                          "    pm.response.to.be.success;",
+                          "});"
+                        ]
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "bearer",
+                      "bearer": [
+                        {
+                          "key": "token",
+                          "value": "{{customer-access-token}}",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "[\n  {\n    \"product\": {\n\t    \"product_id\": \"447\",\n\t    \"qty\": 2,\n\t    \"bundle_option\": {\n\t      \"23\": \"88\",\n\t      \"24\": \"91\"\n\t    },\n\t    \"bundle_option_qty\": {\n\t      \"23\": \"3\",\n\t      \"24\": \"4\"\n\t    }\n\t}\n  }\n]"
+                    },
+                    "url": {
+                      "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                      "host": [
+                        "{{domain}}{{endpoint_carts_id_items}}"
+                      ]
+                    },
+                    "description": "ID: 447\nType: Bundle\nName: Pillow and Throw Set\nSKU (dynamic): hdb010\nURL: pillow-and-throw-set\nCategory: Home & Decor -> Bed & Bath\nPrice: N/A\n\nBundle Items:\nTitle: Accent Pillow\nID: 24\nName: Titian Raw Silk Pillow | Shay Printed Pillow\nSKU: hdb005 | hdb006\nID: 381 | 382\nSelection ID: 91 | 92\nPrice: 125.00 | 210.00\n\nTitle: Decorative Throw\nID: 23\nName: Carnegie Alpaca Throw | Row Throw | Gramercy Throw\nSKU: hdb007 | hdb008 | hdb009\nID: 383 | 384 | 385\nPrice: 275.00 | 240.00 | 275.00\nSelection ID: 88 | 89 | 115"
+                  },
+                  "response": []
+                },
+                {
+                  "name": "Downloadable",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Successfull call', function(){",
+                          "    pm.response.to.be.success;",
+                          "});"
+                        ]
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "bearer",
+                      "bearer": [
+                        {
+                          "key": "token",
+                          "value": "{{customer-access-token}}",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "[\n  {\n    \"product\": {\n\t    \"product_id\": \"563\",\n\t    \"qty\": 1,\n\t    \"links\": [\n\t      \"18\"\n\t    ]\n\t }\n  }\n]"
+                    },
+                    "url": {
+                      "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                      "host": [
+                        "{{domain}}{{endpoint_carts_id_items}}"
+                      ]
+                    },
+                    "description": "ID: 563\nName: Fire [Kalima remix] by Unannounced Guest\nSKU: hbm010\nCategory: Music & Books\nURL: fire-kalima-remix-by-unannounced-guest\nPrice: 2.00\nQty: 1000"
+                  },
+                  "response": []
+                },
+                {
+                  "name": "Grouped",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Successfull call', function(){",
+                          "    pm.response.to.be.success;",
+                          "});"
+                        ]
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "bearer",
+                      "bearer": [
+                        {
+                          "key": "token",
+                          "value": "{{customer-access-token}}",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "[\n  {\n    \"product\": {\n\t    \"product_id\": \"439\",\n\t    \"qty\": 1,\n\t    \"super_group\": {\n\t      \"541\" : 2\n\t    }\n\t  }\n  }\n]"
+                    },
+                    "url": {
+                      "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                      "host": [
+                        "{{domain}}{{endpoint_carts_id_items}}"
+                      ]
+                    },
+                    "description": "ID: 439\nName: Luggage Set\nType: Grouped\nSKU: abl008\nURL: luggage-set\nCategory: Bags & Luggage\n\nSub-Product:\nID: 541 | 377 | 376\nName: Classic Hardshell Suitcase 19\" | Classic Hardshell Suitcase 29\" | Classic Hardshell Suitcase 21\"\nSKU: abl009 | abl007 | abl006\nPrice: 600.00 | 750.00 | 650.00\nQty: 7 | 13 | 15"
+                  },
+                  "response": []
+                },
+                {
+                  "name": "Simple",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Successfull call', function(){",
+                          "    pm.response.to.be.success;",
+                          "});"
+                        ]
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "bearer",
+                      "bearer": [
+                        {
+                          "key": "token",
+                          "value": "{{customer-access-token}}",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "[\n  {\n    \"product\": {\n\t    \"product_id\": \"554\",\n\t    \"qty\": 1\n\t  }\n  }\n]"
+                    },
+                    "url": {
+                      "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                      "host": [
+                        "{{domain}}{{endpoint_carts_id_items}}"
+                      ]
+                    },
+                    "description": "ID: 554\nType: Simple\nName: Swiss Movement Sports Watch\nSKU: acj005\nURL: swiss-movement-sports-watch\nCategory: Jewelry\nPrice: $500.00\nQty: 3"
+                  },
+                  "response": []
+                },
+                {
+                  "name": "GiftCard Combined",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "id": "80c8e513-1bca-429b-a1fb-9b129d4f7efe",
+                        "type": "text/javascript",
+                        "exec": [
+                          "if (pm.variables.get(\"mage_type\") === 'EE') {",
+                          "    pm.test('Successfull call', function(){",
+                          "        pm.response.to.be.success;",
+                          "    });",
+                          "} else {",
+                          "    pm.test(\"Giftcards don't exist in the Community edition\", function () {",
+                          "        pm.response.to.have.status(404);",
+                          "    });",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "bearer",
+                      "bearer": [
+                        {
+                          "key": "token",
+                          "value": "{{customer-access-token}}",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "[\n  {\n    \"product\": {\n\t    \"sku\": \"gif001\",\n\t    \"qty\": 1,\n\t    \"custom_giftcard_amount\": \"75\",\n\t    \"giftcard_sender_name\": \"Some sender name\",\n\t    \"giftcard_sender_email\": \"test@shopgate.com\",\n\t    \"giftcard_recipient_name\": \"Some recipient name\",\n\t    \"giftcard_recipient_email\": \"test2@shopgate.com\",\n\t    \"giftcard_message\": \"Message to recipient\"\n\t  }\n  }\n]"
+                    },
+                    "url": {
+                      "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                      "host": [
+                        "{{domain}}{{endpoint_carts_id_items}}"
+                      ]
+                    },
+                    "description": "Combined type Gift card with custom price"
+                  },
+                  "response": []
+                },
+                {
+                  "name": "GiftCard Virtual CP",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "id": "fa327b11-c19c-48fb-b431-b26cdbe5f546",
+                        "type": "text/javascript",
+                        "exec": [
+                          "if (pm.variables.get(\"mage_type\") === 'EE') {",
+                          "    pm.test('Successfull call', function(){",
+                          "        pm.response.to.be.success;",
+                          "    });",
+                          "} else {",
+                          "    pm.test(\"Giftcards don't exist in the Community edition\", function () {",
+                          "        pm.response.to.have.status(404);",
+                          "    });",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "bearer",
+                      "bearer": [
+                        {
+                          "key": "token",
+                          "value": "{{customer-access-token}}",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "[\n  {\n    \"product\": {\n\t    \"sku\": \"gif003\",\n\t    \"qty\": 1,\n\t    \"custom_giftcard_amount\": \"50\",\n\t    \"giftcard_sender_name\": \"Some sender name\",\n\t    \"giftcard_sender_email\": \"test@shopgate.com\",\n\t    \"giftcard_recipient_name\": \"Some recipient name\",\n\t    \"giftcard_recipient_email\": \"test2@shopgate.com\",\n\t    \"giftcard_message\": \"Message to recipient\"\n\t  }\n  }\n]"
+                    },
+                    "url": {
+                      "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                      "host": [
+                        "{{domain}}{{endpoint_carts_id_items}}"
+                      ]
+                    },
+                    "description": "Virtual card with custom price set"
+                  },
+                  "response": []
+                },
+                {
+                  "name": "GiftCard Virtual Set",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "id": "e40fb867-1ea6-49a3-8742-cbd3f98c0247",
+                        "type": "text/javascript",
+                        "exec": [
+                          "if (pm.variables.get(\"mage_type\") === 'EE') {",
+                          "    pm.test('Successfull call', function(){",
+                          "        pm.response.to.be.success;",
+                          "    });",
+                          "} else {",
+                          "    pm.test(\"Giftcards don't exist in the Community edition\", function () {",
+                          "        pm.response.to.have.status(404);",
+                          "    });",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "bearer",
+                      "bearer": [
+                        {
+                          "key": "token",
+                          "value": "{{customer-access-token}}",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "[\n  {\n    \"product\": {\n\t    \"sku\": \"gif002\",\n\t    \"qty\": 1,\n\t    \"giftcard_sender_name\": \"Some sender name\",\n\t    \"giftcard_sender_email\": \"test@shopgate.com\",\n\t    \"giftcard_recipient_name\": \"Some recipient name\",\n\t    \"giftcard_recipient_email\": \"test2@shopgate.com\",\n\t    \"giftcard_message\": \"Message to recipient\"\n\t  }\n  }\n]"
+                    },
+                    "url": {
+                      "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                      "host": [
+                        "{{domain}}{{endpoint_carts_id_items}}"
+                      ]
+                    },
+                    "description": "Virtual card with custom price set"
+                  },
+                  "response": []
+                }
+              ],
+              "_postman_isSubFolder": true
+            },
+            {
+              "name": "Customer - Update",
+              "description": "",
+              "item": [
+                {
+                  "name": "/carts: customer",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "var jsonData = pm.response.json();",
+                          "if (responseCode.code === 200 && jsonData.hasOwnProperty('cartId')) {",
+                          "    pm.environment.set(\"cartId\", jsonData.cartId);",
+                          "    tests[\"Cart ID is returned\"] = isNumeric(jsonData.cartId) === true;",
+                          "} else {",
+                          "    tests[\"Cart ID is not returned\"] = false;",
+                          "}",
+                          "",
+                          "pm.test('Successfull call', function(){",
+                          "    pm.response.to.be.success;",
+                          "});",
+                          "",
+                          "function isNumeric(n) {",
+                          "  return !isNaN(parseFloat(n)) && isFinite(n);",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "bearer",
+                      "bearer": [
+                        {
+                          "key": "token",
+                          "value": "{{customer-access-token}}",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{}"
+                    },
+                    "url": {
+                      "raw": "{{domain}}{{endpoint_carts}}",
+                      "host": [
+                        "{{domain}}{{endpoint_carts}}"
+                      ]
+                    },
+                    "description": "Creates a customer cart"
+                  },
+                  "response": []
+                },
+                {
+                  "name": "Simple",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Successfull call', function(){",
+                          "    pm.response.to.be.success;",
+                          "});"
+                        ]
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "bearer",
+                      "bearer": [
+                        {
+                          "key": "token",
+                          "value": "{{customer-access-token}}",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "[\n  {\n    \"product\": {\n\t    \"product_id\": \"554\",\n\t    \"qty\": 1\n\t  }\n  }\n]"
+                    },
+                    "url": {
+                      "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                      "host": [
+                        "{{domain}}{{endpoint_carts_id_items}}"
+                      ]
+                    },
+                    "description": "ID: 554\nType: Simple\nName: Swiss Movement Sports Watch\nSKU: acj005\nURL: swiss-movement-sports-watch\nCategory: Jewelry\nPrice: $500.00\nQty: 3"
+                  },
+                  "response": []
+                },
+                {
+                  "name": "Get cart contents",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "var jsonData = pm.response.json();",
+                          "if (responseCode.code === 200 && jsonData.items.length > 0) {",
+                          "    pm.environment.set(\"cart_item_id\", jsonData.items[0].item_id);",
+                          "} else {",
+                          "    tests[\"Not 200 code or no cart items returned\"] = false;",
+                          "}",
+                          "",
+                          "pm.test(\"Status code is 200\", function () {",
+                          "    pm.response.to.have.status(200);",
+                          "});",
+                          "",
+                          "pm.test(\"Initial quantity is 1 after adding simple product\", function () {",
+                          "    pm.expect(jsonData.items[0].qty).to.eql(1);",
+                          "});"
+                        ]
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "bearer",
+                      "bearer": [
+                        {
+                          "key": "token",
+                          "value": "{{customer-access-token}}",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{}"
+                    },
+                    "url": {
+                      "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                      "host": [
+                        "{{domain}}{{endpoint_carts}}"
+                      ],
+                      "path": [
+                        "{{cartId}}"
+                      ]
+                    },
+                    "description": "Creates a customer cart"
+                  },
+                  "response": []
+                },
+                {
+                  "name": "Update simple",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Successfull call', function(){",
+                          "    pm.response.to.be.success;",
+                          "});"
+                        ]
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "bearer",
+                      "bearer": [
+                        {
+                          "key": "token",
+                          "value": "{{customer-access-token}}",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "[\n  {\n  \t\"cartItemId\": \"{{cart_item_id}}\",\n    \"product\": {\n\t    \"product_id\": \"554\",\n\t    \"qty\": 3\n\t  }\n  }\n]"
+                    },
+                    "url": {
+                      "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                      "host": [
+                        "{{domain}}{{endpoint_carts_id_items}}"
+                      ]
+                    },
+                    "description": "ID: 554\nType: Simple\nName: Swiss Movement Sports Watch\nSKU: acj005\nURL: swiss-movement-sports-watch\nCategory: Jewelry\nPrice: $500.00\nQty: 3"
+                  },
+                  "response": []
+                },
+                {
+                  "name": "Get cart contents",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test(\"Status code is 200\", function () {",
+                          "    pm.response.to.have.status(200);",
+                          "});",
+                          "",
+                          "pm.test(\"Qty is now updated to 3 for the previously inserted simple product\", function () {",
+                          "    var jsonData = pm.response.json();",
+                          "    pm.expect(jsonData.items[0].qty).to.eql(3);",
+                          "});"
+                        ]
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "bearer",
+                      "bearer": [
+                        {
+                          "key": "token",
+                          "value": "{{customer-access-token}}",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{}"
+                    },
+                    "url": {
+                      "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                      "host": [
+                        "{{domain}}{{endpoint_carts}}"
+                      ],
+                      "path": [
+                        "{{cartId}}"
+                      ]
+                    },
+                    "description": "Creates a customer cart"
+                  },
+                  "response": []
+                }
+              ],
+              "_postman_isSubFolder": true
+            },
+            {
+              "name": "Customer - Delete",
+              "description": "",
+              "item": [
+                {
+                  "name": "All item removal",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Successfull call', function(){",
+                          "    pm.response.to.be.success;",
+                          "});"
+                        ]
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "bearer",
+                      "bearer": [
+                        {
+                          "key": "token",
+                          "value": "{{customer-access-token}}",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "method": "DELETE",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": ""
+                    },
+                    "url": {
+                      "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                      "host": [
+                        "{{domain}}{{endpoint_carts_id_items}}"
+                      ]
+                    },
+                    "description": ""
+                  },
+                  "response": []
+                },
+                {
+                  "name": "Check cart for no items",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test(\"Status code is 200\", function () {",
+                          "    pm.response.to.have.status(200);",
+                          "});",
+                          "",
+                          "pm.test(\"No items in cart\", function () {",
+                          "    var jsonData = pm.response.json();",
+                          "    pm.expect(jsonData.items).to.be.empty;",
+                          "});"
+                        ]
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "bearer",
+                      "bearer": [
+                        {
+                          "key": "token",
+                          "value": "{{customer-access-token}}",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{}"
+                    },
+                    "url": {
+                      "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                      "host": [
+                        "{{domain}}{{endpoint_carts}}"
+                      ],
+                      "path": [
+                        "{{cartId}}"
+                      ]
+                    },
+                    "description": "Creates a customer cart"
+                  },
+                  "response": []
+                }
+              ],
+              "_postman_isSubFolder": true
+            },
+            {
+              "name": "Customer - Errors",
+              "description": "",
+              "item": [
+                {
+                  "name": "Bad product ID",
+                  "description": "",
+                  "item": [
+                    {
+                      "name": "/carts: customer",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "var jsonData = pm.response.json();",
+                              "if (responseCode.code === 200 && jsonData.hasOwnProperty('cartId')) {",
+                              "    pm.environment.set(\"cartId\", jsonData.cartId);",
+                              "    tests[\"Cart ID is returned\"] = isNumeric(jsonData.cartId) === true;",
+                              "} else {",
+                              "    tests[\"Cart ID is not returned\"] = false;",
+                              "}",
+                              "",
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});",
+                              "",
+                              "function isNumeric(n) {",
+                              "  return !isNaN(parseFloat(n)) && isFinite(n);",
+                              "}"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{customer-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "POST",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "{}"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts}}"
+                          ]
+                        },
+                        "description": "Creates a customer cart"
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Cfg + non-existing",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test(\"Product does not exist\", function () {",
+                              "    pm.response.to.have.status(404);",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{customer-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "POST",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "[\n  {\n    \"product\": {\n       \"product_id\": \"422\",\n    \t\"qty\": 1,\n    \t\"super_attribute\": {\n           \"92\": \"17\",\n           \"180\": \"76\"\n        }\n    }\n  },\n  {\n    \"product\": {\n\t    \"product_id\": \"9999\",\n\t    \"qty\": 1,\n\t    \"links\": [\n\t      \"18\"\n\t    ]\n\t }\n  }\n]"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts_id_items}}"
+                          ]
+                        },
+                        "description": ""
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Cart should be empty",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "var jsonData = pm.response.json();",
+                              "",
+                              "pm.test(\"Status code is 200\", function () {",
+                              "    pm.response.to.have.status(200);",
+                              "});",
+                              "",
+                              "pm.test(\"No products were added\", function () {",
+                              "    pm.expect(jsonData.items.length).to.eql(0);",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{customer-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "GET",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "{}"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts}}"
+                          ],
+                          "path": [
+                            "{{cartId}}"
+                          ]
+                        },
+                        "description": "Creates a customer cart"
+                      },
+                      "response": []
+                    }
+                  ],
+                  "_postman_isSubFolder": true
+                },
+                {
+                  "name": "Out of stock",
+                  "description": "",
+                  "item": [
+                    {
+                      "name": "/carts: customer",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "var jsonData = pm.response.json();",
+                              "if (responseCode.code === 200 && jsonData.cartId) {",
+                              "    pm.environment.set(\"cartId\", jsonData.cartId);",
+                              "    tests[\"Cart ID is returned\"] = isNumeric(jsonData.cartId) === true;",
+                              "} else {",
+                              "    tests[\"Cart ID is not returned\"] = false;",
+                              "}",
+                              "",
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});",
+                              "",
+                              "function isNumeric(n) {",
+                              "  return !isNaN(parseFloat(n)) && isFinite(n);",
+                              "}"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{customer-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "POST",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "{}"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts}}"
+                          ]
+                        },
+                        "description": "Creates a customer cart"
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Add simple, qty 999",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{customer-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "POST",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "[\n  {\n    \"product\": {\n\t    \"product_id\": \"554\",\n\t    \"qty\": 999\n\t  }\n  }\n]"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts_id_items}}"
+                          ]
+                        },
+                        "description": "ID: 554\nType: Simple\nName: Swiss Movement Sports Watch\nSKU: acj005\nURL: swiss-movement-sports-watch\nCategory: Jewelry\nPrice: $500.00\nQty: 3"
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Check cart errors",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "var jsonData = pm.response.json();",
+                              "",
+                              "pm.test(\"Status code is 200\", function () {",
+                              "    pm.response.to.have.status(200);",
+                              "});",
+                              "",
+                              "pm.test(\"Qty is indeed 999\", function () {",
+                              "    pm.expect(jsonData.items[0].qty).to.eql(999);",
+                              "});",
+                              "",
+                              "pm.test(\"Cart has errors\", function () {",
+                              "    pm.expect(jsonData.has_error).to.eql(true);",
+                              "});",
+                              "",
+                              "pm.test(\"Item has errors & error array\", function () {",
+                              "    pm.expect(jsonData.items[0].has_error).to.eql(true);",
+                              "    pm.expect(jsonData.items[0].errors).to.not.be.empty;",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{customer-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "GET",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "{}"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts}}"
+                          ],
+                          "path": [
+                            "{{cartId}}"
+                          ]
+                        },
+                        "description": "Creates a customer cart"
+                      },
+                      "response": []
+                    }
+                  ],
+                  "_postman_isSubFolder": true
+                }
+              ],
+              "_postman_isSubFolder": true
+            },
+            {
+              "name": "Guest - Add",
+              "description": "",
+              "item": [
+                {
+                  "name": "Nominal product",
+                  "description": "",
+                  "item": [
+                    {
+                      "name": "/carts: Guest Cart",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "var jsonData = pm.response.json();",
+                              "if (responseCode.code === 200 && jsonData.hasOwnProperty('cartId')) {",
+                              "    pm.environment.set(\"cartId\", jsonData.cartId);",
+                              "    tests[\"Cart ID is returned\"] = isNumeric(jsonData.cartId) === true;",
+                              "} else {",
+                              "    tests[\"Cart ID is not returned\"] = false;",
+                              "}",
+                              "",
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});",
+                              "",
+                              "function isNumeric(n) {",
+                              "  return !isNaN(parseFloat(n)) && isFinite(n);",
+                              "}"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{guest-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "POST",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "{}"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts}}"
+                          ]
+                        },
+                        "description": "Creates a guest cart and assigns the local cartId variable from the one returned"
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Nominal",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{guest-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "POST",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "[\n  {\n    \"product\": {\n\t    \"sku\": \"mem000\",\n\t    \"qty\": 1,\n\t    \"options\": {\n\t      \"6\": {\n\t        \"month\": \"01\",\n\t        \"day\": \"17\",\n\t        \"year\": \"2017\"\n\t      }\n\t    },\n\t    \"recurring_profile_start_datetime\":\"09/15/2017 09:49 PM\"\n\t  }\n  }\n]\n\n"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts_id_items}}"
+                          ]
+                        },
+                        "description": "Nominal and recurring profile item"
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Simple",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test(\"Cannot add another product with nominal in cart\", function () {",
+                              "    pm.response.to.have.status(400);",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{guest-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "POST",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "[\n  {\n    \"product\": {\n\t    \"product_id\": \"554\",\n\t    \"qty\": 1\n\t  }\n  }\n]"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts_id_items}}"
+                          ]
+                        },
+                        "description": "ID: 554\nType: Simple\nName: Swiss Movement Sports Watch\nSKU: acj005\nURL: swiss-movement-sports-watch\nCategory: Jewelry\nPrice: $500.00\nQty: 3"
+                      },
+                      "response": []
+                    }
+                  ],
+                  "_postman_isSubFolder": true
+                },
+                {
+                  "name": "/carts: Guest Cart",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "var jsonData = pm.response.json();",
+                          "if (responseCode.code === 200 && jsonData.hasOwnProperty('cartId')) {",
+                          "    pm.environment.set(\"cartId\", jsonData.cartId);",
+                          "    tests[\"Cart ID is returned\"] = isNumeric(jsonData.cartId) === true;",
+                          "} else {",
+                          "    tests[\"Cart ID is not returned\"] = false;",
+                          "}",
+                          "",
+                          "pm.test('Successfull call', function(){",
+                          "    pm.response.to.be.success;",
+                          "});",
+                          "",
+                          "function isNumeric(n) {",
+                          "  return !isNaN(parseFloat(n)) && isFinite(n);",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "bearer",
+                      "bearer": [
+                        {
+                          "key": "token",
+                          "value": "{{guest-access-token}}",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{}"
+                    },
+                    "url": {
+                      "raw": "{{domain}}{{endpoint_carts}}",
+                      "host": [
+                        "{{domain}}{{endpoint_carts}}"
+                      ]
+                    },
+                    "description": "Creates a guest cart and assigns the local cartId variable from the one returned"
+                  },
+                  "response": []
+                },
+                {
+                  "name": "Bundle + Configurable",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Successfull call', function(){",
+                          "    pm.response.to.be.success;",
+                          "});"
+                        ]
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "bearer",
+                      "bearer": [
+                        {
+                          "key": "token",
+                          "value": "{{guest-access-token}}",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "[\n  {\n    \"product\": {\n      \"product_id\": \"447\",\n      \"qty\": 2,\n      \"bundle_option\": {\n        \"23\": \"88\",\n        \"24\": \"91\"\n      },\n      \"bundle_option_qty\": {\n        \"23\": \"3\",\n        \"24\": \"4\"\n      }\n    }\n  },\n  {\n    \"product\": {\n       \"product_id\": \"422\",\n    \t\"qty\": 1,\n    \t\"super_attribute\": {\n           \"92\": \"17\",\n           \"180\": \"76\"\n        }\n    }\n  }\n]"
+                    },
+                    "url": {
+                      "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                      "host": [
+                        "{{domain}}{{endpoint_carts_id_items}}"
+                      ]
+                    },
+                    "description": ""
+                  },
+                  "response": []
+                },
+                {
+                  "name": "Add Configurable: Skirt",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Successfull call', function(){",
+                          "    pm.response.to.be.success;",
+                          "});"
+                        ]
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "bearer",
+                      "bearer": [
+                        {
+                          "key": "token",
+                          "value": "{{guest-access-token}}",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "[\n  {\n\t    \"product\": {\n\t\t    \"product_id\": \"422\",\n\t\t    \"qty\": 1,\n\t\t    \"super_attribute\": {\n\t\t\t      \"92\": \"17\",\n\t\t\t      \"180\": \"76\"\n\t\t\t    }\n\t\t}\n  }\n]"
+                    },
+                    "url": {
+                      "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                      "host": [
+                        "{{domain}}{{endpoint_carts_id_items}}"
+                      ]
+                    },
+                    "description": "ID: 422\nType: Configurable\nName: Essex Pencil Skirt\nSKU: wsd000c\nCategory: Dresses & Skirts\nPrice: $185.00\n\nSub-Products:\nID: 297 | 298 | 299 | 300 | 301\nName: Essex Pencil Skirt\nSKU: wsd000 | wsd001 | wsd002 | wsd003 | wsd004\nColor (ID: 92): Charcoal (ID: 17)\nSize (ID: 180): 2 (ID: 76) | 4 (ID: 75) | 6 (ID: 74) | 8 (ID: 73) | 10 (ID: 72)"
+                  },
+                  "response": []
+                },
+                {
+                  "name": "Bundled",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Successfull call', function(){",
+                          "    pm.response.to.be.success;",
+                          "});"
+                        ]
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "bearer",
+                      "bearer": [
+                        {
+                          "key": "token",
+                          "value": "{{guest-access-token}}",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "[\n  {\n    \"product\": {\n\t    \"product_id\": \"447\",\n\t    \"qty\": 2,\n\t    \"bundle_option\": {\n\t      \"23\": \"88\",\n\t      \"24\": \"91\"\n\t    },\n\t    \"bundle_option_qty\": {\n\t      \"23\": \"3\",\n\t      \"24\": \"4\"\n\t    }\n\t}\n  }\n]"
+                    },
+                    "url": {
+                      "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                      "host": [
+                        "{{domain}}{{endpoint_carts_id_items}}"
+                      ]
+                    },
+                    "description": "ID: 447\nType: Bundle\nName: Pillow and Throw Set\nSKU (dynamic): hdb010\nURL: pillow-and-throw-set\nCategory: Home & Decor -> Bed & Bath\nPrice: N/A\n\nBundle Items:\nTitle: Accent Pillow\nID: 24\nName: Titian Raw Silk Pillow | Shay Printed Pillow\nSKU: hdb005 | hdb006\nID: 381 | 382\nSelection ID: 91 | 92\nPrice: 125.00 | 210.00\n\nTitle: Decorative Throw\nID: 23\nName: Carnegie Alpaca Throw | Row Throw | Gramercy Throw\nSKU: hdb007 | hdb008 | hdb009\nID: 383 | 384 | 385\nPrice: 275.00 | 240.00 | 275.00\nSelection ID: 88 | 89 | 115"
+                  },
+                  "response": []
+                },
+                {
+                  "name": "Downloadable",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Successfull call', function(){",
+                          "    pm.response.to.be.success;",
+                          "});"
+                        ]
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "bearer",
+                      "bearer": [
+                        {
+                          "key": "token",
+                          "value": "{{guest-access-token}}",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "[\n  {\n    \"product\": {\n\t    \"product_id\": \"563\",\n\t    \"qty\": 1,\n\t    \"links\": [\n\t      \"18\"\n\t    ]\n\t }\n  }\n]"
+                    },
+                    "url": {
+                      "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                      "host": [
+                        "{{domain}}{{endpoint_carts_id_items}}"
+                      ]
+                    },
+                    "description": "ID: 563\nName: Fire [Kalima remix] by Unannounced Guest\nSKU: hbm010\nCategory: Music & Books\nURL: fire-kalima-remix-by-unannounced-guest\nPrice: 2.00\nQty: 1000"
+                  },
+                  "response": []
+                },
+                {
+                  "name": "Grouped",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Successfull call', function(){",
+                          "    pm.response.to.be.success;",
+                          "});"
+                        ]
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "bearer",
+                      "bearer": [
+                        {
+                          "key": "token",
+                          "value": "{{guest-access-token}}",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "[\n  {\n    \"product\": {\n\t    \"product_id\": \"439\",\n\t    \"qty\": 1,\n\t    \"super_group\": {\n\t      \"541\" : 2\n\t    }\n\t  }\n  }\n]"
+                    },
+                    "url": {
+                      "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                      "host": [
+                        "{{domain}}{{endpoint_carts_id_items}}"
+                      ]
+                    },
+                    "description": "ID: 439\nName: Luggage Set\nType: Grouped\nSKU: abl008\nURL: luggage-set\nCategory: Bags & Luggage\n\nSub-Product:\nID: 541 | 377 | 376\nName: Classic Hardshell Suitcase 19\" | Classic Hardshell Suitcase 29\" | Classic Hardshell Suitcase 21\"\nSKU: abl009 | abl007 | abl006\nPrice: 600.00 | 750.00 | 650.00\nQty: 7 | 13 | 15"
+                  },
+                  "response": []
+                },
+                {
+                  "name": "Simple",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Successfull call', function(){",
+                          "    pm.response.to.be.success;",
+                          "});"
+                        ]
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "bearer",
+                      "bearer": [
+                        {
+                          "key": "token",
+                          "value": "{{guest-access-token}}",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "[\n  {\n    \"product\": {\n\t    \"product_id\": \"554\",\n\t    \"qty\": 1\n\t  }\n  }\n]"
+                    },
+                    "url": {
+                      "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                      "host": [
+                        "{{domain}}{{endpoint_carts_id_items}}"
+                      ]
+                    },
+                    "description": "ID: 554\nType: Simple\nName: Swiss Movement Sports Watch\nSKU: acj005\nURL: swiss-movement-sports-watch\nCategory: Jewelry\nPrice: $500.00\nQty: 3"
+                  },
+                  "response": []
+                },
+                {
+                  "name": "GiftCard Combined",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "id": "2721dfff-e833-4863-b072-cf5ddd78ce2d",
+                        "type": "text/javascript",
+                        "exec": [
+                          "if (pm.variables.get(\"mage_type\") === 'EE') {",
+                          "    pm.test('Successfull call', function(){",
+                          "        pm.response.to.be.success;",
+                          "    });",
+                          "} else {",
+                          "    pm.test(\"Giftcards don't exist in the Community edition\", function () {",
+                          "        pm.response.to.have.status(404);",
+                          "    });",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "bearer",
+                      "bearer": [
+                        {
+                          "key": "token",
+                          "value": "{{guest-access-token}}",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "[\n  {\n    \"product\": {\n\t    \"sku\": \"gif001\",\n\t    \"qty\": 1,\n\t    \"custom_giftcard_amount\": \"75\",\n\t    \"giftcard_sender_name\": \"Some sender name\",\n\t    \"giftcard_sender_email\": \"test@shopgate.com\",\n\t    \"giftcard_recipient_name\": \"Some recipient name\",\n\t    \"giftcard_recipient_email\": \"test2@shopgate.com\",\n\t    \"giftcard_message\": \"Message to recipient\"\n\t  }\n  }\n]"
+                    },
+                    "url": {
+                      "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                      "host": [
+                        "{{domain}}{{endpoint_carts_id_items}}"
+                      ]
+                    },
+                    "description": "Combined type Gift card with custom price"
+                  },
+                  "response": []
+                },
+                {
+                  "name": "GiftCard Virtual CP",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "id": "6949ae5b-fa51-4534-a9f1-9cddb7881023",
+                        "type": "text/javascript",
+                        "exec": [
+                          "if (pm.variables.get(\"mage_type\") === 'EE') {",
+                          "    pm.test('Successfull call', function(){",
+                          "        pm.response.to.be.success;",
+                          "    });",
+                          "} else {",
+                          "    pm.test(\"Giftcards don't exist in the Community edition\", function () {",
+                          "        pm.response.to.have.status(404);",
+                          "    });",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "bearer",
+                      "bearer": [
+                        {
+                          "key": "token",
+                          "value": "{{guest-access-token}}",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "[\n  {\n    \"product\": {\n\t    \"sku\": \"gif003\",\n\t    \"qty\": 1,\n\t    \"custom_giftcard_amount\": \"50\",\n\t    \"giftcard_sender_name\": \"Some sender name\",\n\t    \"giftcard_sender_email\": \"test@shopgate.com\",\n\t    \"giftcard_recipient_name\": \"Some recipient name\",\n\t    \"giftcard_recipient_email\": \"test2@shopgate.com\",\n\t    \"giftcard_message\": \"Message to recipient\"\n\t  }\n  }\n]"
+                    },
+                    "url": {
+                      "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                      "host": [
+                        "{{domain}}{{endpoint_carts_id_items}}"
+                      ]
+                    },
+                    "description": "Virtual card with custom price set"
+                  },
+                  "response": []
+                },
+                {
+                  "name": "GiftCard Virtual Set",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "id": "0edd61ba-1533-4c9e-8bf7-a0ca2691d49a",
+                        "type": "text/javascript",
+                        "exec": [
+                          "if (pm.variables.get(\"mage_type\") === 'EE') {",
+                          "    pm.test('Successfull call', function(){",
+                          "        pm.response.to.be.success;",
+                          "    });",
+                          "} else {",
+                          "    pm.test(\"Giftcards don't exist in the Community edition\", function () {",
+                          "        pm.response.to.have.status(404);",
+                          "    });",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "bearer",
+                      "bearer": [
+                        {
+                          "key": "token",
+                          "value": "{{guest-access-token}}",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "[\n  {\n    \"product\": {\n\t    \"sku\": \"gif002\",\n\t    \"qty\": 1,\n\t    \"giftcard_sender_name\": \"Some sender name\",\n\t    \"giftcard_sender_email\": \"test@shopgate.com\",\n\t    \"giftcard_recipient_name\": \"Some recipient name\",\n\t    \"giftcard_recipient_email\": \"test2@shopgate.com\",\n\t    \"giftcard_message\": \"Message to recipient\"\n\t  }\n  }\n]"
+                    },
+                    "url": {
+                      "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                      "host": [
+                        "{{domain}}{{endpoint_carts_id_items}}"
+                      ]
+                    },
+                    "description": "Virtual card with custom price set"
+                  },
+                  "response": []
+                }
+              ],
+              "_postman_isSubFolder": true
+            },
+            {
+              "name": "Guest - Update",
+              "description": "",
+              "item": [
+                {
+                  "name": "Advanced",
+                  "description": "",
+                  "item": [
+                    {
+                      "name": "/carts: Guest Cart",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "var jsonData = pm.response.json();",
+                              "if (responseCode.code === 200 && jsonData.hasOwnProperty('cartId')) {",
+                              "    pm.environment.set(\"cartId\", jsonData.cartId);",
+                              "    tests[\"Cart ID is returned\"] = isNumeric(jsonData.cartId) === true;",
+                              "} else {",
+                              "    tests[\"Cart ID is not returned\"] = false;",
+                              "}",
+                              "",
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});",
+                              "",
+                              "function isNumeric(n) {",
+                              "  return !isNaN(parseFloat(n)) && isFinite(n);",
+                              "}"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{guest-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "POST",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "{}"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts}}"
+                          ]
+                        },
+                        "description": "Creates a guest cart and assigns the local cartId variable from the one returned"
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Add Simple",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{guest-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "POST",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "[\n  {\n    \"product\": {\n\t    \"product_id\": \"554\",\n\t    \"qty\": 1\n\t  }\n  }\n]"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts_id_items}}"
+                          ]
+                        },
+                        "description": "ID: 554\nType: Simple\nName: Swiss Movement Sports Watch\nSKU: acj005\nURL: swiss-movement-sports-watch\nCategory: Jewelry\nPrice: $500.00\nQty: 3"
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Cart: qty 1",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "var jsonData = pm.response.json();",
+                              "if (responseCode.code === 200 && jsonData.items.length > 0) {",
+                              "    pm.environment.set(\"cart_item_id\", jsonData.items[0].item_id);",
+                              "} else {",
+                              "    tests[\"Not 200 code or no cart items returned\"] = false;",
+                              "}",
+                              "",
+                              "pm.test(\"Status code is 200\", function () {",
+                              "    pm.response.to.have.status(200);",
+                              "});",
+                              "",
+                              "pm.test(\"Initial quantity is 1 after adding simple product\", function () {",
+                              "    pm.expect(jsonData.items[0].qty).to.eql(1);",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{guest-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "GET",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "{}"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts}}"
+                          ],
+                          "path": [
+                            "{{cartId}}"
+                          ]
+                        },
+                        "description": "calls a customer cart as guest"
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Update simple & add confg",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{guest-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "POST",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "[\n  {\n  \t\"cartItemId\": \"{{cart_item_id}}\",\n    \"product\": {\n\t    \"product_id\": \"554\",\n\t    \"qty\": 3\n\t  }\n  },\n  {\n\t    \"product\": {\n\t\t    \"product_id\": \"422\",\n\t\t    \"qty\": 1,\n\t\t    \"super_attribute\": {\n\t\t\t      \"92\": \"17\",\n\t\t\t      \"180\": \"76\"\n\t\t\t    }\n\t\t}\n  }\n]"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts_id_items}}"
+                          ]
+                        },
+                        "description": ""
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Cart: qty updated",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test(\"Status code is 200\", function () {",
+                              "    pm.response.to.have.status(200);",
+                              "});",
+                              "",
+                              "pm.test(\"Qty is now updated to 3 for the previously inserted simple product & qty 1 for the configurable\", function () {",
+                              "    var jsonData = pm.response.json();",
+                              "    pm.expect(jsonData.items[0].qty).to.eql(3);",
+                              "    pm.expect(jsonData.items[1].qty).to.eql(1);",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{guest-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "GET",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "{}"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts}}"
+                          ],
+                          "path": [
+                            "{{cartId}}"
+                          ]
+                        },
+                        "description": ""
+                      },
+                      "response": []
+                    }
+                  ],
+                  "_postman_isSubFolder": true
+                },
+                {
+                  "name": "/carts: Guest Cart",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "var jsonData = pm.response.json();",
+                          "if (responseCode.code === 200 && jsonData.hasOwnProperty('cartId')) {",
+                          "    pm.environment.set(\"cartId\", jsonData.cartId);",
+                          "    tests[\"Cart ID is returned\"] = isNumeric(jsonData.cartId) === true;",
+                          "} else {",
+                          "    tests[\"Cart ID is not returned\"] = false;",
+                          "}",
+                          "",
+                          "pm.test('Successfull call', function(){",
+                          "    pm.response.to.be.success;",
+                          "});",
+                          "",
+                          "function isNumeric(n) {",
+                          "  return !isNaN(parseFloat(n)) && isFinite(n);",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "bearer",
+                      "bearer": [
+                        {
+                          "key": "token",
+                          "value": "{{guest-access-token}}",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{}"
+                    },
+                    "url": {
+                      "raw": "{{domain}}{{endpoint_carts}}",
+                      "host": [
+                        "{{domain}}{{endpoint_carts}}"
+                      ]
+                    },
+                    "description": "Creates a guest cart and assigns the local cartId variable from the one returned"
+                  },
+                  "response": []
+                },
+                {
+                  "name": "Add Simple",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Successfull call', function(){",
+                          "    pm.response.to.be.success;",
+                          "});"
+                        ]
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "bearer",
+                      "bearer": [
+                        {
+                          "key": "token",
+                          "value": "{{guest-access-token}}",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "[\n  {\n    \"product\": {\n\t    \"product_id\": \"554\",\n\t    \"qty\": 1\n\t  }\n  }\n]"
+                    },
+                    "url": {
+                      "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                      "host": [
+                        "{{domain}}{{endpoint_carts_id_items}}"
+                      ]
+                    },
+                    "description": "ID: 554\nType: Simple\nName: Swiss Movement Sports Watch\nSKU: acj005\nURL: swiss-movement-sports-watch\nCategory: Jewelry\nPrice: $500.00\nQty: 3"
+                  },
+                  "response": []
+                },
+                {
+                  "name": "Cart: qty 1",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "var jsonData = pm.response.json();",
+                          "if (responseCode.code === 200 && jsonData.items.length > 0) {",
+                          "    pm.environment.set(\"cart_item_id\", jsonData.items[0].item_id);",
+                          "} else {",
+                          "    tests[\"Not 200 code or no cart items returned\"] = false;",
+                          "}",
+                          "",
+                          "pm.test(\"Status code is 200\", function () {",
+                          "    pm.response.to.have.status(200);",
+                          "});",
+                          "",
+                          "pm.test(\"Initial quantity is 1 after adding simple product\", function () {",
+                          "    pm.expect(jsonData.items[0].qty).to.eql(1);",
+                          "});"
+                        ]
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "bearer",
+                      "bearer": [
+                        {
+                          "key": "token",
+                          "value": "{{guest-access-token}}",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{}"
+                    },
+                    "url": {
+                      "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                      "host": [
+                        "{{domain}}{{endpoint_carts}}"
+                      ],
+                      "path": [
+                        "{{cartId}}"
+                      ]
+                    },
+                    "description": "calls a customer cart as guest"
+                  },
+                  "response": []
+                },
+                {
+                  "name": "Update simple",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Successfull call', function(){",
+                          "    pm.response.to.be.success;",
+                          "});"
+                        ]
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "bearer",
+                      "bearer": [
+                        {
+                          "key": "token",
+                          "value": "{{guest-access-token}}",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "[\n  {\n  \t\"cartItemId\": \"{{cart_item_id}}\",\n    \"product\": {\n\t    \"product_id\": \"554\",\n\t    \"qty\": 3\n\t  }\n  }\n]"
+                    },
+                    "url": {
+                      "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                      "host": [
+                        "{{domain}}{{endpoint_carts_id_items}}"
+                      ]
+                    },
+                    "description": "ID: 554\nType: Simple\nName: Swiss Movement Sports Watch\nSKU: acj005\nURL: swiss-movement-sports-watch\nCategory: Jewelry\nPrice: $500.00\nQty: 3"
+                  },
+                  "response": []
+                },
+                {
+                  "name": "Cart: qty updated",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test(\"Status code is 200\", function () {",
+                          "    pm.response.to.have.status(200);",
+                          "});",
+                          "",
+                          "pm.test(\"Qty is now updated to 3 for the previously inserted simple product\", function () {",
+                          "    var jsonData = pm.response.json();",
+                          "    pm.expect(jsonData.items[0].qty).to.eql(3);",
+                          "});"
+                        ]
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "bearer",
+                      "bearer": [
+                        {
+                          "key": "token",
+                          "value": "{{guest-access-token}}",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{}"
+                    },
+                    "url": {
+                      "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                      "host": [
+                        "{{domain}}{{endpoint_carts}}"
+                      ],
+                      "path": [
+                        "{{cartId}}"
+                      ]
+                    },
+                    "description": ""
+                  },
+                  "response": []
+                },
+                {
+                  "name": "Simple",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Successfull call', function(){",
+                          "    pm.response.to.be.success;",
+                          "});"
+                        ]
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "bearer",
+                      "bearer": [
+                        {
+                          "key": "token",
+                          "value": "{{guest-access-token}}",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "[\n  {\n    \"product\": {\n\t    \"product_id\": \"554\",\n\t    \"qty\": 1\n\t  }\n  }\n]"
+                    },
+                    "url": {
+                      "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                      "host": [
+                        "{{domain}}{{endpoint_carts_id_items}}"
+                      ]
+                    },
+                    "description": "ID: 554\nType: Simple\nName: Swiss Movement Sports Watch\nSKU: acj005\nURL: swiss-movement-sports-watch\nCategory: Jewelry\nPrice: $500.00\nQty: 3"
+                  },
+                  "response": []
+                }
+              ],
+              "_postman_isSubFolder": true
+            },
+            {
+              "name": "Guest - Delete all",
+              "description": "",
+              "item": [
+                {
+                  "name": "Delete All",
+                  "description": "",
+                  "item": [
+                    {
+                      "name": "/carts: Guest Cart",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "var jsonData = pm.response.json();",
+                              "if (responseCode.code === 200 && jsonData.hasOwnProperty('cartId')) {",
+                              "    pm.environment.set(\"cartId\", jsonData.cartId);",
+                              "    tests[\"Cart ID is returned\"] = isNumeric(jsonData.cartId) === true;",
+                              "} else {",
+                              "    tests[\"Cart ID is not returned\"] = false;",
+                              "}",
+                              "",
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});",
+                              "",
+                              "function isNumeric(n) {",
+                              "  return !isNaN(parseFloat(n)) && isFinite(n);",
+                              "}"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{guest-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "POST",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "{}"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts}}"
+                          ]
+                        },
+                        "description": "Creates a guest cart and assigns the local cartId variable from the one returned"
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Add Simple",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{guest-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "POST",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "[\n  {\n    \"product\": {\n\t    \"product_id\": \"554\",\n\t    \"qty\": 1\n\t  }\n  }\n]"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts_id_items}}"
+                          ]
+                        },
+                        "description": "ID: 554\nType: Simple\nName: Swiss Movement Sports Watch\nSKU: acj005\nURL: swiss-movement-sports-watch\nCategory: Jewelry\nPrice: $500.00\nQty: 3"
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "All item removal",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{guest-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "DELETE",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": ""
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts_id_items}}"
+                          ]
+                        },
+                        "description": ""
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Check cart for no items",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test(\"Status code is 200\", function () {",
+                              "    pm.response.to.have.status(200);",
+                              "});",
+                              "",
+                              "pm.test(\"No items in cart\", function () {",
+                              "    var jsonData = pm.response.json();",
+                              "    pm.expect(jsonData.items).to.be.empty;",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{guest-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "GET",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "{}"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts}}"
+                          ],
+                          "path": [
+                            "{{cartId}}"
+                          ]
+                        },
+                        "description": "Creates a customer cart"
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "/carts: Guest Cart",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "var jsonData = pm.response.json();",
+                              "if (responseCode.code === 200 && jsonData.hasOwnProperty('cartId')) {",
+                              "    pm.environment.set(\"cartId\", jsonData.cartId);",
+                              "    tests[\"Cart ID is returned\"] = isNumeric(jsonData.cartId) === true;",
+                              "} else {",
+                              "    tests[\"Cart ID is not returned\"] = false;",
+                              "}",
+                              "",
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});",
+                              "",
+                              "function isNumeric(n) {",
+                              "  return !isNaN(parseFloat(n)) && isFinite(n);",
+                              "}"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{guest-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "POST",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "{}"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts}}"
+                          ]
+                        },
+                        "description": "Creates a guest cart and assigns the local cartId variable from the one returned"
+                      },
+                      "response": []
+                    }
+                  ],
+                  "_postman_isSubFolder": true
+                },
+                {
+                  "name": "Delete by IDs",
+                  "description": "Retrieves the items in the cart and deletes them using their id's",
+                  "item": [
+                    {
+                      "name": "Add Simple",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{guest-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "POST",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "[\n  {\n    \"product\": {\n\t    \"product_id\": \"554\",\n\t    \"qty\": 1\n\t  }\n  }\n]"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts_id_items}}"
+                          ]
+                        },
+                        "description": "ID: 554\nType: Simple\nName: Swiss Movement Sports Watch\nSKU: acj005\nURL: swiss-movement-sports-watch\nCategory: Jewelry\nPrice: $500.00\nQty: 3"
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Get all cart item ids",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "var jsonData = pm.response.json();",
+                              "if (responseCode.code === 200 && jsonData.items.length > 0) {",
+                              "    var items = '';",
+                              "    jsonData.items.forEach(function(item) {",
+                              "        items += item.item_id + ',';",
+                              "    });",
+                              "    pm.environment.set(\"cart_items_to_remove\", items);",
+                              "} else {",
+                              "    tests[\"Not 200 code or no cart items returned\"] = false;",
+                              "}",
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{guest-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "GET",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "{}"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts}}"
+                          ],
+                          "path": [
+                            "{{cartId}}"
+                          ]
+                        },
+                        "description": ""
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "{cartId}/items?cartItemIds",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{guest-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "DELETE",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": ""
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts_id_items}}?cartItemIds={{cart_items_to_remove}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts_id_items}}"
+                          ],
+                          "query": [
+                            {
+                              "key": "cartItemIds",
+                              "value": "{{cart_items_to_remove}}",
+                              "equals": true
+                            }
+                          ]
+                        },
+                        "description": "Delete cart items by ids provided"
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Check all items are deleted",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});",
+                              "",
+                              "pm.test(\"No items in cart\", function () {",
+                              "    var jsonData = pm.response.json();",
+                              "    pm.expect(jsonData.items).to.be.empty;",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{guest-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "GET",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "{}"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts}}"
+                          ],
+                          "path": [
+                            "{{cartId}}"
+                          ]
+                        },
+                        "description": ""
+                      },
+                      "response": []
+                    }
+                  ],
+                  "_postman_isSubFolder": true
+                }
+              ],
+              "_postman_isSubFolder": true
+            }
+          ],
+          "_postman_isSubFolder": true
+        },
+        {
+          "name": "Coupon",
+          "description": "",
+          "item": [
+            {
+              "name": "Customer",
+              "description": "",
+              "item": [
+                {
+                  "name": "Add",
+                  "description": "",
+                  "item": [
+                    {
+                      "name": "Auto-Gen",
+                      "description": "",
+                      "item": [
+                        {
+                          "name": "/carts: customer",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "var jsonData = pm.response.json();",
+                                  "if (responseCode.code === 200 && jsonData.hasOwnProperty('cartId')) {",
+                                  "    pm.environment.set(\"cartId\", jsonData.cartId);",
+                                  "    tests[\"Cart ID is returned\"] = isNumeric(jsonData.cartId) === true;",
+                                  "} else {",
+                                  "    tests[\"Cart ID is not returned\"] = false;",
+                                  "}",
+                                  "",
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});",
+                                  "",
+                                  "function isNumeric(n) {",
+                                  "  return !isNaN(parseFloat(n)) && isFinite(n);",
+                                  "}"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts}}"
+                              ]
+                            },
+                            "description": "Creates a customer cart"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Add Simple: 500",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "[\n  {\n    \"product\": {\n\t    \"product_id\": \"554\",\n\t    \"qty\": 1\n\t  }\n  }\n]"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts_id_items}}"
+                              ]
+                            },
+                            "description": "ID: 554\nType: Simple\nName: Swiss Movement Sports Watch\nSKU: acj005\nURL: swiss-movement-sports-watch\nCategory: Jewelry\nPrice: $500.00\nQty: 3"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Add 10% off coupon",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "[\n  {\n    \t\"coupon\": {\n\t\t    \"couponCode\":\"3I5REXK80NUN\"\n\t\t}\n  }\n]"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts_id_items}}"
+                              ]
+                            },
+                            "description": "Autogenerated coupon code.\nCondition for coupon is:\nGroup: Not-Logged-In, General, VIP, Wholesale; \nIf item in cart has \"Price in cart\" = 500"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Check coupon exists",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test(\"Status code is 200\", function () {",
+                                  "    pm.response.to.have.status(200);",
+                                  "});",
+                                  "",
+                                  "pm.test(\"3I5REXK80NUN code exists\", function () {",
+                                  "    var jsonData = pm.response.json();",
+                                  "    pm.expect(jsonData.coupon_code).to.eql(\"3I5REXK80NUN\");",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "GET",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts}}"
+                              ],
+                              "path": [
+                                "{{cartId}}"
+                              ]
+                            },
+                            "description": ""
+                          },
+                          "response": []
+                        }
+                      ],
+                      "_postman_isSubFolder": true
+                    },
+                    {
+                      "name": "/carts: customer",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "var jsonData = pm.response.json();",
+                              "if (responseCode.code === 200 && jsonData.hasOwnProperty('cartId')) {",
+                              "    pm.environment.set(\"cartId\", jsonData.cartId);",
+                              "    tests[\"Cart ID is returned\"] = isNumeric(jsonData.cartId) === true;",
+                              "} else {",
+                              "    tests[\"Cart ID is not returned\"] = false;",
+                              "}",
+                              "",
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});",
+                              "",
+                              "function isNumeric(n) {",
+                              "  return !isNaN(parseFloat(n)) && isFinite(n);",
+                              "}"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{customer-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "POST",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "{}"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts}}"
+                          ]
+                        },
+                        "description": "Creates a customer cart"
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Add Configurable: Boots",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{customer-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "POST",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "[\n  {\n    \t\"product\": {\n\t\t    \"product_id\": \"431\",\n\t\t    \"qty\": 1,\n\t\t    \"super_attribute\": {\n\t\t\t      \"92\": \"20\",\n\t\t\t      \"186\": \"102\"\n\t\t\t}\n\t\t}\n  }\n]"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts_id_items}}"
+                          ]
+                        },
+                        "description": "ID: 431\nType: Configurable\nName: Ann Ankle Boot\nSKU: aws005c\nURL: borgha-ankle-boot\nPrice: $470.00\nCategory: Shoes\n\n\nSub-Products:\nID: 345 | 346 | 347 | 348 | 349\nName: Ann Ankle Boot\nSKU: aws005 | aws006 | aws007 | aws008 | aws009\nColor (ID: 92): Black (ID: 20)\nShoe size (ID: 186): 6 (ID: 102) | 7 (ID: 101) | 8 (ID: 100) | 9 (ID: 99) | 10 (ID: 98)"
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Check no discount",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "var jsonData = pm.response.json();",
+                              "if (responseCode.code === 200 && jsonData.items.length > 0) {",
+                              "    pm.environment.set(\"cart_item_id\", jsonData.items[0].item_id);",
+                              "} else {",
+                              "    tests[\"Not 200 code or no cart items returned\"] = false;",
+                              "}",
+                              "",
+                              "pm.test(\"Status code is 200\", function () {",
+                              "    pm.response.to.have.status(200);",
+                              "});",
+                              "",
+                              "pm.test(\"Coupon code not set\", function () {",
+                              "    var jsonData = pm.response.json();",
+                              "    pm.expect(jsonData.coupon_code).to.eql(null);",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{customer-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "GET",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "{}"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts}}"
+                          ],
+                          "path": [
+                            "{{cartId}}"
+                          ]
+                        },
+                        "description": ""
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Add 10 flat off coupon",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{customer-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "POST",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "[\n  {\n    \t\"coupon\": {\n\t\t    \"couponCode\":\"Register10\"\n\t\t}\n  }\n]"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts_id_items}}"
+                          ]
+                        },
+                        "description": "Condition for coupon is Group: General, subtotal: 200+"
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Check Register10 exists",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test(\"Status code is 200\", function () {",
+                              "    pm.response.to.have.status(200);",
+                              "});",
+                              "",
+                              "pm.test(\"Register10 code exists\", function () {",
+                              "    var jsonData = pm.response.json();",
+                              "    pm.expect(jsonData.coupon_code).to.eql(\"Register10\");",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{customer-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "GET",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "{}"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts}}"
+                          ],
+                          "path": [
+                            "{{cartId}}"
+                          ]
+                        },
+                        "description": ""
+                      },
+                      "response": []
+                    }
+                  ],
+                  "_postman_isSubFolder": true
+                },
+                {
+                  "name": "Update",
+                  "description": "Run after the add tests",
+                  "item": [
+                    {
+                      "name": "/carts: customer",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "var jsonData = pm.response.json();",
+                              "if (responseCode.code === 200 && jsonData.hasOwnProperty('cartId')) {",
+                              "    pm.environment.set(\"cartId\", jsonData.cartId);",
+                              "    tests[\"Cart ID is returned\"] = isNumeric(jsonData.cartId) === true;",
+                              "} else {",
+                              "    tests[\"Cart ID is not returned\"] = false;",
+                              "}",
+                              "",
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});",
+                              "",
+                              "function isNumeric(n) {",
+                              "  return !isNaN(parseFloat(n)) && isFinite(n);",
+                              "}"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{customer-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "POST",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "{}"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts}}"
+                          ]
+                        },
+                        "description": "Creates a customer cart"
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Add Configurable: Boots",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{customer-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "POST",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "[\n  {\n    \t\"product\": {\n\t\t    \"product_id\": \"431\",\n\t\t    \"qty\": 1,\n\t\t    \"super_attribute\": {\n\t\t\t      \"92\": \"20\",\n\t\t\t      \"186\": \"102\"\n\t\t\t}\n\t\t}\n  }\n]"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts_id_items}}"
+                          ]
+                        },
+                        "description": "ID: 431\nType: Configurable\nName: Ann Ankle Boot\nSKU: aws005c\nURL: borgha-ankle-boot\nPrice: $470.00\nCategory: Shoes\n\n\nSub-Products:\nID: 345 | 346 | 347 | 348 | 349\nName: Ann Ankle Boot\nSKU: aws005 | aws006 | aws007 | aws008 | aws009\nColor (ID: 92): Black (ID: 20)\nShoe size (ID: 186): 6 (ID: 102) | 7 (ID: 101) | 8 (ID: 100) | 9 (ID: 99) | 10 (ID: 98)"
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Check no discount",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test(\"Status code is 200\", function () {",
+                              "    pm.response.to.have.status(200);",
+                              "});",
+                              "",
+                              "pm.test(\"Coupon code not set\", function () {",
+                              "    var jsonData = pm.response.json();",
+                              "    pm.expect(jsonData.coupon_code).to.eql(null);",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{customer-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "GET",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "{}"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts}}"
+                          ],
+                          "path": [
+                            "{{cartId}}"
+                          ]
+                        },
+                        "description": ""
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Add 10 flat off coupon",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{customer-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "POST",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "[\n  {\n    \t\"coupon\": {\n\t\t    \"couponCode\":\"Register10\"\n\t\t}\n  }\n]"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts_id_items}}"
+                          ]
+                        },
+                        "description": "Condition for coupon is Group: General, subtotal: 200+"
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Check Register10 exists",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test(\"Status code is 200\", function () {",
+                              "    pm.response.to.have.status(200);",
+                              "});",
+                              "",
+                              "pm.test(\"Register10 code exists\", function () {",
+                              "    var jsonData = pm.response.json();",
+                              "    pm.expect(jsonData.coupon_code).to.eql(\"Register10\");",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{customer-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "GET",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "{}"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts}}"
+                          ],
+                          "path": [
+                            "{{cartId}}"
+                          ]
+                        },
+                        "description": ""
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Add Configurable: Skirt",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{customer-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "POST",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "[\n  {\n\t    \"product\": {\n\t\t    \"product_id\": \"422\",\n\t\t    \"qty\": 1,\n\t\t    \"super_attribute\": {\n\t\t\t      \"92\": \"17\",\n\t\t\t      \"180\": \"76\"\n\t\t\t    }\n\t\t}\n  }\n]"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts_id_items}}"
+                          ]
+                        },
+                        "description": "ID: 422\nType: Configurable\nName: Essex Pencil Skirt\nSKU: wsd000c\nCategory: Dresses & Skirts\nPrice: $185.00\n\nSub-Products:\nID: 297 | 298 | 299 | 300 | 301\nName: Essex Pencil Skirt\nSKU: wsd000 | wsd001 | wsd002 | wsd003 | wsd004\nColor (ID: 92): Charcoal (ID: 17)\nSize (ID: 180): 2 (ID: 76) | 4 (ID: 75) | 6 (ID: 74) | 8 (ID: 73) | 10 (ID: 72)"
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Add 25% off coupon",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{customer-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "POST",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "[\n  {\n    \t\"coupon\": {\n\t\t    \"couponCode\":\"25OFF\"\n\t\t}\n  }\n]"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts_id_items}}"
+                          ]
+                        },
+                        "description": "Conditions: for customer group General and Category: Apparel"
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Check 25OFF exists",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test(\"Status code is 200\", function () {",
+                              "    pm.response.to.have.status(200);",
+                              "});",
+                              "",
+                              "pm.test(\"25 off code exists\", function () {",
+                              "    var jsonData = pm.response.json();",
+                              "    pm.expect(jsonData.coupon_code).to.eql(\"25OFF\");",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{customer-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "GET",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "{}"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts}}"
+                          ],
+                          "path": [
+                            "{{cartId}}"
+                          ]
+                        },
+                        "description": ""
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Add 10 flat via Update",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{customer-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "POST",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "[\n  {\t\t\n  \t\t\"cartItemId\": \"1234\",\n    \t\"coupon\": {\n\t\t    \"couponCode\":\"Register10\"\n\t\t}\n  }\n]"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts_id_items}}"
+                          ]
+                        },
+                        "description": "Condition for coupon is Group: General, subtotal: 200+"
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Check Register10 exists",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test(\"Status code is 200\", function () {",
+                              "    pm.response.to.have.status(200);",
+                              "});",
+                              "",
+                              "pm.test(\"Register10 code exists\", function () {",
+                              "    var jsonData = pm.response.json();",
+                              "    pm.expect(jsonData.coupon_code).to.eql(\"Register10\");",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{customer-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "GET",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "{}"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts}}"
+                          ],
+                          "path": [
+                            "{{cartId}}"
+                          ]
+                        },
+                        "description": ""
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Add 10 flat off coupon",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{customer-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "POST",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "[\n  {\n    \t\"coupon\": {\n\t\t    \"couponCode\":\"Register10\"\n\t\t}\n  }\n]"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts_id_items}}"
+                          ]
+                        },
+                        "description": "Condition for coupon is Group: General, subtotal: 200+"
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Add empty coupon",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{customer-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "POST",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "[\n  {\n    \t\"coupon\": {\n\t\t    \"couponCode\":\"\"\n\t\t}\n  }\n]"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts_id_items}}"
+                          ]
+                        },
+                        "description": "Condition for coupon is Group: General, subtotal: 200+"
+                      },
+                      "response": []
+                    }
+                  ],
+                  "_postman_isSubFolder": true
+                },
+                {
+                  "name": "Delete",
+                  "description": "",
+                  "item": [
+                    {
+                      "name": "Via Empty Add",
+                      "description": "",
+                      "item": [
+                        {
+                          "name": "/carts: customer",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "var jsonData = pm.response.json();",
+                                  "if (responseCode.code === 200 && jsonData.hasOwnProperty('cartId')) {",
+                                  "    pm.environment.set(\"cartId\", jsonData.cartId);",
+                                  "    tests[\"Cart ID is returned\"] = isNumeric(jsonData.cartId) === true;",
+                                  "} else {",
+                                  "    tests[\"Cart ID is not returned\"] = false;",
+                                  "}",
+                                  "",
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});",
+                                  "",
+                                  "function isNumeric(n) {",
+                                  "  return !isNaN(parseFloat(n)) && isFinite(n);",
+                                  "}"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts}}"
+                              ]
+                            },
+                            "description": "Creates a customer cart"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Add Configurable: Boots",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "[\n  {\n    \t\"product\": {\n\t\t    \"product_id\": \"431\",\n\t\t    \"qty\": 1,\n\t\t    \"super_attribute\": {\n\t\t\t      \"92\": \"20\",\n\t\t\t      \"186\": \"102\"\n\t\t\t}\n\t\t}\n  }\n]"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts_id_items}}"
+                              ]
+                            },
+                            "description": "ID: 431\nType: Configurable\nName: Ann Ankle Boot\nSKU: aws005c\nURL: borgha-ankle-boot\nPrice: $470.00\nCategory: Shoes\n\n\nSub-Products:\nID: 345 | 346 | 347 | 348 | 349\nName: Ann Ankle Boot\nSKU: aws005 | aws006 | aws007 | aws008 | aws009\nColor (ID: 92): Black (ID: 20)\nShoe size (ID: 186): 6 (ID: 102) | 7 (ID: 101) | 8 (ID: 100) | 9 (ID: 99) | 10 (ID: 98)"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Check no discount",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test(\"Status code is 200\", function () {",
+                                  "    pm.response.to.have.status(200);",
+                                  "});",
+                                  "",
+                                  "pm.test(\"Coupon code not set\", function () {",
+                                  "    var jsonData = pm.response.json();",
+                                  "    pm.expect(jsonData.coupon_code).to.eql(null);",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "GET",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts}}"
+                              ],
+                              "path": [
+                                "{{cartId}}"
+                              ]
+                            },
+                            "description": ""
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Add 10 flat off coupon",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "[\n  {\n    \t\"coupon\": {\n\t\t    \"couponCode\":\"Register10\"\n\t\t}\n  }\n]"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts_id_items}}"
+                              ]
+                            },
+                            "description": "Condition for coupon is Group: General, subtotal: 200+"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Check Register10 exists",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test(\"Status code is 200\", function () {",
+                                  "    pm.response.to.have.status(200);",
+                                  "});",
+                                  "",
+                                  "pm.test(\"Register10 code exists\", function () {",
+                                  "    var jsonData = pm.response.json();",
+                                  "    pm.expect(jsonData.coupon_code).to.eql(\"Register10\");",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "GET",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts}}"
+                              ],
+                              "path": [
+                                "{{cartId}}"
+                              ]
+                            },
+                            "description": ""
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Add empty coupon",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "[\n  {\n    \t\"coupon\": {\n\t\t    \"couponCode\":\"\"\n\t\t}\n  }\n]"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts_id_items}}"
+                              ]
+                            },
+                            "description": "Condition for coupon is Group: General, subtotal: 200+"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Check no discount",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test(\"Status code is 200\", function () {",
+                                  "    pm.response.to.have.status(200);",
+                                  "});",
+                                  "",
+                                  "pm.test(\"Coupon code not set\", function () {",
+                                  "    var jsonData = pm.response.json();",
+                                  "    pm.expect(jsonData.coupon_code).to.eql(null);",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "GET",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts}}"
+                              ],
+                              "path": [
+                                "{{cartId}}"
+                              ]
+                            },
+                            "description": ""
+                          },
+                          "response": []
+                        }
+                      ],
+                      "_postman_isSubFolder": true
+                    },
+                    {
+                      "name": "Via query",
+                      "description": "",
+                      "item": [
+                        {
+                          "name": "/carts: customer",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "var jsonData = pm.response.json();",
+                                  "if (responseCode.code === 200 && jsonData.hasOwnProperty('cartId')) {",
+                                  "    pm.environment.set(\"cartId\", jsonData.cartId);",
+                                  "    tests[\"Cart ID is returned\"] = isNumeric(jsonData.cartId) === true;",
+                                  "} else {",
+                                  "    tests[\"Cart ID is not returned\"] = false;",
+                                  "}",
+                                  "",
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});",
+                                  "",
+                                  "function isNumeric(n) {",
+                                  "  return !isNaN(parseFloat(n)) && isFinite(n);",
+                                  "}"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts}}"
+                              ]
+                            },
+                            "description": "Creates a customer cart"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Add Configurable: Boots",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "[\n  {\n    \t\"product\": {\n\t\t    \"product_id\": \"431\",\n\t\t    \"qty\": 1,\n\t\t    \"super_attribute\": {\n\t\t\t      \"92\": \"20\",\n\t\t\t      \"186\": \"102\"\n\t\t\t}\n\t\t}\n  }\n]"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts_id_items}}"
+                              ]
+                            },
+                            "description": "ID: 431\nType: Configurable\nName: Ann Ankle Boot\nSKU: aws005c\nURL: borgha-ankle-boot\nPrice: $470.00\nCategory: Shoes\n\n\nSub-Products:\nID: 345 | 346 | 347 | 348 | 349\nName: Ann Ankle Boot\nSKU: aws005 | aws006 | aws007 | aws008 | aws009\nColor (ID: 92): Black (ID: 20)\nShoe size (ID: 186): 6 (ID: 102) | 7 (ID: 101) | 8 (ID: 100) | 9 (ID: 99) | 10 (ID: 98)"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Check no discount",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test(\"Status code is 200\", function () {",
+                                  "    pm.response.to.have.status(200);",
+                                  "});",
+                                  "",
+                                  "pm.test(\"Coupon code not set\", function () {",
+                                  "    var jsonData = pm.response.json();",
+                                  "    pm.expect(jsonData.coupon_code).to.eql(null);",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "GET",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts}}"
+                              ],
+                              "path": [
+                                "{{cartId}}"
+                              ]
+                            },
+                            "description": ""
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Add 10 flat off coupon",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "[\n  {\n    \t\"coupon\": {\n\t\t    \"couponCode\":\"Register10\"\n\t\t}\n  }\n]"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts_id_items}}"
+                              ]
+                            },
+                            "description": "Condition for coupon is Group: General, subtotal: 200+"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Check Register10 exists",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test(\"Status code is 200\", function () {",
+                                  "    pm.response.to.have.status(200);",
+                                  "});",
+                                  "",
+                                  "pm.test(\"Register10 code exists\", function () {",
+                                  "    var jsonData = pm.response.json();",
+                                  "    pm.expect(jsonData.coupon_code).to.eql(\"Register10\");",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "GET",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts}}"
+                              ],
+                              "path": [
+                                "{{cartId}}"
+                              ]
+                            },
+                            "description": ""
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Use ?cartItemIds=",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "DELETE",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": ""
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts_id_items}}?cartItemIds=COUPON_XXX",
+                              "host": [
+                                "{{domain}}{{endpoint_carts_id_items}}"
+                              ],
+                              "query": [
+                                {
+                                  "key": "cartItemIds",
+                                  "value": "COUPON_XXX",
+                                  "equals": true
+                                }
+                              ]
+                            },
+                            "description": ""
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Check no discount",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "var jsonData = pm.response.json();",
+                                  "pm.test(\"Status code is 200\", function () {",
+                                  "    pm.response.to.have.status(200);",
+                                  "});",
+                                  "",
+                                  "pm.test(\"Coupon code not set\", function () {",
+                                  "    pm.expect(jsonData.coupon_code).to.eql(null);",
+                                  "});",
+                                  "",
+                                  "pm.test(\"Still have items in cart\", function () {",
+                                  "    pm.expect(jsonData.items).to.be.not.empty;",
+                                  "});",
+                                  "",
+                                  ""
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "GET",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts}}"
+                              ],
+                              "path": [
+                                "{{cartId}}"
+                              ]
+                            },
+                            "description": ""
+                          },
+                          "response": []
+                        }
+                      ],
+                      "_postman_isSubFolder": true
+                    }
+                  ],
+                  "_postman_isSubFolder": true
+                }
+              ],
+              "_postman_isSubFolder": true
+            },
+            {
+              "name": "Guest",
+              "description": "",
+              "item": [
+                {
+                  "name": "Add",
+                  "description": "",
+                  "item": [
+                    {
+                      "name": "Auto-Gen",
+                      "description": "",
+                      "item": [
+                        {
+                          "name": "/carts: Guest Cart",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "var jsonData = pm.response.json();",
+                                  "if (responseCode.code === 200 && jsonData.hasOwnProperty('cartId')) {",
+                                  "    pm.environment.set(\"cartId\", jsonData.cartId);",
+                                  "    tests[\"Cart ID is returned\"] = isNumeric(jsonData.cartId) === true;",
+                                  "} else {",
+                                  "    tests[\"Cart ID is not returned\"] = false;",
+                                  "}",
+                                  "",
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});",
+                                  "",
+                                  "function isNumeric(n) {",
+                                  "  return !isNaN(parseFloat(n)) && isFinite(n);",
+                                  "}"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{guest-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts}}"
+                              ]
+                            },
+                            "description": "Creates a guest cart and assigns the local cartId variable from the one returned"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Add Simple: $500",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{guest-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "[\n  {\n    \"product\": {\n\t    \"product_id\": \"554\",\n\t    \"qty\": 1\n\t  }\n  }\n]"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts_id_items}}"
+                              ]
+                            },
+                            "description": "ID: 554\nType: Simple\nName: Swiss Movement Sports Watch\nSKU: acj005\nURL: swiss-movement-sports-watch\nCategory: Jewelry\nPrice: $500.00\nQty: 3"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Add 10% off coupon",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{guest-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "[\n  {\n    \t\"coupon\": {\n\t\t    \"couponCode\":\"3I5REXK80NUN\"\n\t\t}\n  }\n]"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts_id_items}}"
+                              ]
+                            },
+                            "description": "Autogenerated coupon code.\nCondition for coupon is:\nGroup: Not-Logged-In, General, VIP, Wholesale; \nIf item in cart has \"Price in cart\" = 500"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Coupon is in cart",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test(\"Status code is 200\", function () {",
+                                  "    pm.response.to.have.status(200);",
+                                  "});",
+                                  "",
+                                  "pm.test(\"3I5REXK80NUN code exists\", function () {",
+                                  "    var jsonData = pm.response.json();",
+                                  "    pm.expect(jsonData.coupon_code).to.eql(\"3I5REXK80NUN\");",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{guest-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "GET",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts}}"
+                              ],
+                              "path": [
+                                "{{cartId}}"
+                              ]
+                            },
+                            "description": ""
+                          },
+                          "response": []
+                        }
+                      ],
+                      "_postman_isSubFolder": true
+                    },
+                    {
+                      "name": "/carts: Guest Cart",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "var jsonData = pm.response.json();",
+                              "if (responseCode.code === 200 && jsonData.hasOwnProperty('cartId')) {",
+                              "    pm.environment.set(\"cartId\", jsonData.cartId);",
+                              "    tests[\"Cart ID is returned\"] = isNumeric(jsonData.cartId) === true;",
+                              "} else {",
+                              "    tests[\"Cart ID is not returned\"] = false;",
+                              "}",
+                              "",
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});",
+                              "",
+                              "function isNumeric(n) {",
+                              "  return !isNaN(parseFloat(n)) && isFinite(n);",
+                              "}"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{guest-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "POST",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "{}"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts}}"
+                          ]
+                        },
+                        "description": "Creates a guest cart and assigns the local cartId variable from the one returned"
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Add Configurable: Skirt",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{guest-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "POST",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "[\n  {\n\t    \"product\": {\n\t\t    \"product_id\": \"422\",\n\t\t    \"qty\": 1,\n\t\t    \"super_attribute\": {\n\t\t\t      \"92\": \"17\",\n\t\t\t      \"180\": \"76\"\n\t\t\t    }\n\t\t}\n  }\n]"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts_id_items}}"
+                          ]
+                        },
+                        "description": "ID: 422\nType: Configurable\nName: Essex Pencil Skirt\nSKU: wsd000c\nCategory: Dresses & Skirts\nPrice: $185.00\n\nSub-Products:\nID: 297 | 298 | 299 | 300 | 301\nName: Essex Pencil Skirt\nSKU: wsd000 | wsd001 | wsd002 | wsd003 | wsd004\nColor (ID: 92): Charcoal (ID: 17)\nSize (ID: 180): 2 (ID: 76) | 4 (ID: 75) | 6 (ID: 74) | 8 (ID: 73) | 10 (ID: 72)"
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Add 15 flat off coupon",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{guest-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "POST",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "[\n  {\n    \t\"coupon\": {\n\t\t    \"couponCode\":\"evening15\"\n\t\t}\n  }\n]"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts_id_items}}"
+                          ]
+                        },
+                        "description": "Condition for coupon is:\nGroup: Not-Logged-In, General, VIP, Private Sales Member; \nCategories: Dresses & Skirts, Dresses;"
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Check evening15 exists",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test(\"Status code is 200\", function () {",
+                              "    pm.response.to.have.status(200);",
+                              "});",
+                              "",
+                              "pm.test(\"evening15 code exists\", function () {",
+                              "    var jsonData = pm.response.json();",
+                              "    pm.expect(jsonData.coupon_code).to.eql(\"evening15\");",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{guest-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "GET",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "{}"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts}}"
+                          ],
+                          "path": [
+                            "{{cartId}}"
+                          ]
+                        },
+                        "description": ""
+                      },
+                      "response": []
+                    }
+                  ],
+                  "_postman_isSubFolder": true
+                },
+                {
+                  "name": "Update",
+                  "description": "",
+                  "item": [
+                    {
+                      "name": "/carts: Guest Cart",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "var jsonData = pm.response.json();",
+                              "if (responseCode.code === 200 && jsonData.hasOwnProperty('cartId')) {",
+                              "    pm.environment.set(\"cartId\", jsonData.cartId);",
+                              "    tests[\"Cart ID is returned\"] = isNumeric(jsonData.cartId) === true;",
+                              "} else {",
+                              "    tests[\"Cart ID is not returned\"] = false;",
+                              "}",
+                              "",
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});",
+                              "",
+                              "function isNumeric(n) {",
+                              "  return !isNaN(parseFloat(n)) && isFinite(n);",
+                              "}"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{guest-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "POST",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "{}"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts}}"
+                          ]
+                        },
+                        "description": "Creates a guest cart and assigns the local cartId variable from the one returned"
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Add Configurable: Skirt",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{guest-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "POST",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "[\n  {\n\t    \"product\": {\n\t\t    \"product_id\": \"422\",\n\t\t    \"qty\": 1,\n\t\t    \"super_attribute\": {\n\t\t\t      \"92\": \"17\",\n\t\t\t      \"180\": \"76\"\n\t\t\t    }\n\t\t}\n  }\n]"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts_id_items}}"
+                          ]
+                        },
+                        "description": "ID: 422\nType: Configurable\nName: Essex Pencil Skirt\nSKU: wsd000c\nCategory: Dresses & Skirts\nPrice: $185.00\n\nSub-Products:\nID: 297 | 298 | 299 | 300 | 301\nName: Essex Pencil Skirt\nSKU: wsd000 | wsd001 | wsd002 | wsd003 | wsd004\nColor (ID: 92): Charcoal (ID: 17)\nSize (ID: 180): 2 (ID: 76) | 4 (ID: 75) | 6 (ID: 74) | 8 (ID: 73) | 10 (ID: 72)"
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Add 15 flat off coupon",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{guest-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "POST",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "[\n  {\n    \t\"coupon\": {\n\t\t    \"couponCode\":\"evening15\"\n\t\t}\n  }\n]"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts_id_items}}"
+                          ]
+                        },
+                        "description": "Condition for coupon is:\nGroup: Not-Logged-In, General, VIP, Private Sales Member; \nCategories: Dresses & Skirts, Dresses;"
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Check evening15 exists",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test(\"Status code is 200\", function () {",
+                              "    pm.response.to.have.status(200);",
+                              "});",
+                              "",
+                              "pm.test(\"evening15 code exists\", function () {",
+                              "    var jsonData = pm.response.json();",
+                              "    pm.expect(jsonData.coupon_code).to.eql(\"evening15\");",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{guest-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "GET",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "{}"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts}}"
+                          ],
+                          "path": [
+                            "{{cartId}}"
+                          ]
+                        },
+                        "description": ""
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Update with empty",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{guest-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "POST",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "[\n  {\n  \t\t\"cartItemId\": \"1234\",\n    \t\"coupon\": {\n\t\t    \"couponCode\":\"\"\n\t\t}\n  }\n]"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts_id_items}}"
+                          ]
+                        },
+                        "description": "Condition for coupon is:\nGroup: Not-Logged-In, General, VIP, Private Sales Member; \nCategories: Dresses & Skirts, Dresses;"
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Check no discount",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test(\"Status code is 200\", function () {",
+                              "    pm.response.to.have.status(200);",
+                              "});",
+                              "",
+                              "pm.test(\"Coupon code not set\", function () {",
+                              "    var jsonData = pm.response.json();",
+                              "    pm.expect(jsonData.coupon_code).to.eql(null);",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{guest-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "GET",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "{}"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts}}"
+                          ],
+                          "path": [
+                            "{{cartId}}"
+                          ]
+                        },
+                        "description": ""
+                      },
+                      "response": []
+                    }
+                  ],
+                  "_postman_isSubFolder": true
+                },
+                {
+                  "name": "Delete",
+                  "description": "",
+                  "item": [
+                    {
+                      "name": "Via Empty All",
+                      "description": "",
+                      "item": [
+                        {
+                          "name": "/carts: guest",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "var jsonData = pm.response.json();",
+                                  "if (responseCode.code === 200 && jsonData.hasOwnProperty('cartId')) {",
+                                  "    pm.environment.set(\"cartId\", jsonData.cartId);",
+                                  "    tests[\"Cart ID is returned\"] = isNumeric(jsonData.cartId) === true;",
+                                  "} else {",
+                                  "    tests[\"Cart ID is not returned\"] = false;",
+                                  "}",
+                                  "",
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});",
+                                  "",
+                                  "function isNumeric(n) {",
+                                  "  return !isNaN(parseFloat(n)) && isFinite(n);",
+                                  "}"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{guest-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts}}"
+                              ]
+                            },
+                            "description": "Creates a guest cart and assigns the local cartId variable from the one returned"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Add Configurable: Skirt",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{guest-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "[\n  {\n\t    \"product\": {\n\t\t    \"product_id\": \"422\",\n\t\t    \"qty\": 1,\n\t\t    \"super_attribute\": {\n\t\t\t      \"92\": \"17\",\n\t\t\t      \"180\": \"76\"\n\t\t\t    }\n\t\t}\n  }\n]"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts_id_items}}"
+                              ]
+                            },
+                            "description": "ID: 422\nType: Configurable\nName: Essex Pencil Skirt\nSKU: wsd000c\nCategory: Dresses & Skirts\nPrice: $185.00\n\nSub-Products:\nID: 297 | 298 | 299 | 300 | 301\nName: Essex Pencil Skirt\nSKU: wsd000 | wsd001 | wsd002 | wsd003 | wsd004\nColor (ID: 92): Charcoal (ID: 17)\nSize (ID: 180): 2 (ID: 76) | 4 (ID: 75) | 6 (ID: 74) | 8 (ID: 73) | 10 (ID: 72)"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Add 15 flat off coupon",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{guest-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "[\n  {\n    \t\"coupon\": {\n\t\t    \"couponCode\":\"evening15\"\n\t\t}\n  }\n]"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts_id_items}}"
+                              ]
+                            },
+                            "description": "Condition for coupon is:\nGroup: Not-Logged-In, General, VIP, Private Sales Member; \nCategories: Dresses & Skirts, Dresses;"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Check evening15 exists",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test(\"Status code is 200\", function () {",
+                                  "    pm.response.to.have.status(200);",
+                                  "});",
+                                  "",
+                                  "pm.test(\"evening15 code exists\", function () {",
+                                  "    var jsonData = pm.response.json();",
+                                  "    pm.expect(jsonData.coupon_code).to.eql(\"evening15\");",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{guest-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "GET",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts}}"
+                              ],
+                              "path": [
+                                "{{cartId}}"
+                              ]
+                            },
+                            "description": ""
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Add empty coupon",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{guest-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "[\n  {\n    \t\"coupon\": {\n\t\t    \"couponCode\":\"\"\n\t\t}\n  }\n]"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts_id_items}}"
+                              ]
+                            },
+                            "description": "Condition for coupon is Group: General, subtotal: 200+"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Check no discount",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test(\"Status code is 200\", function () {",
+                                  "    pm.response.to.have.status(200);",
+                                  "});",
+                                  "",
+                                  "pm.test(\"Coupon code not set\", function () {",
+                                  "    var jsonData = pm.response.json();",
+                                  "    pm.expect(jsonData.coupon_code).to.eql(null);",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{guest-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "GET",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts}}"
+                              ],
+                              "path": [
+                                "{{cartId}}"
+                              ]
+                            },
+                            "description": ""
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "/carts: guest",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "var jsonData = pm.response.json();",
+                                  "if (responseCode.code === 200 && jsonData.hasOwnProperty('cartId')) {",
+                                  "    pm.environment.set(\"cartId\", jsonData.cartId);",
+                                  "    tests[\"Cart ID is returned\"] = isNumeric(jsonData.cartId) === true;",
+                                  "} else {",
+                                  "    tests[\"Cart ID is not returned\"] = false;",
+                                  "}",
+                                  "",
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});",
+                                  "",
+                                  "function isNumeric(n) {",
+                                  "  return !isNaN(parseFloat(n)) && isFinite(n);",
+                                  "}"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{guest-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts}}"
+                              ]
+                            },
+                            "description": "Creates a guest cart and assigns the local cartId variable from the one returned"
+                          },
+                          "response": []
+                        }
+                      ],
+                      "_postman_isSubFolder": true
+                    },
+                    {
+                      "name": "Via query",
+                      "description": "",
+                      "item": [
+                        {
+                          "name": "/carts: guest",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "var jsonData = pm.response.json();",
+                                  "if (responseCode.code === 200 && jsonData.hasOwnProperty('cartId')) {",
+                                  "    pm.environment.set(\"cartId\", jsonData.cartId);",
+                                  "    tests[\"Cart ID is returned\"] = isNumeric(jsonData.cartId) === true;",
+                                  "} else {",
+                                  "    tests[\"Cart ID is not returned\"] = false;",
+                                  "}",
+                                  "",
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});",
+                                  "",
+                                  "function isNumeric(n) {",
+                                  "  return !isNaN(parseFloat(n)) && isFinite(n);",
+                                  "}"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{guest-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts}}"
+                              ]
+                            },
+                            "description": "Creates a guest cart and assigns the local cartId variable from the one returned"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Add Configurable: Skirt",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{guest-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "[\n  {\n\t    \"product\": {\n\t\t    \"product_id\": \"422\",\n\t\t    \"qty\": 1,\n\t\t    \"super_attribute\": {\n\t\t\t      \"92\": \"17\",\n\t\t\t      \"180\": \"76\"\n\t\t\t    }\n\t\t}\n  }\n]"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts_id_items}}"
+                              ]
+                            },
+                            "description": "ID: 422\nType: Configurable\nName: Essex Pencil Skirt\nSKU: wsd000c\nCategory: Dresses & Skirts\nPrice: $185.00\n\nSub-Products:\nID: 297 | 298 | 299 | 300 | 301\nName: Essex Pencil Skirt\nSKU: wsd000 | wsd001 | wsd002 | wsd003 | wsd004\nColor (ID: 92): Charcoal (ID: 17)\nSize (ID: 180): 2 (ID: 76) | 4 (ID: 75) | 6 (ID: 74) | 8 (ID: 73) | 10 (ID: 72)"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Add 15 flat off coupon",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{guest-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "[\n  {\n    \t\"coupon\": {\n\t\t    \"couponCode\":\"evening15\"\n\t\t}\n  }\n]"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts_id_items}}"
+                              ]
+                            },
+                            "description": "Condition for coupon is:\nGroup: Not-Logged-In, General, VIP, Private Sales Member; \nCategories: Dresses & Skirts, Dresses;"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Check evening15 exists copy",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test(\"Status code is 200\", function () {",
+                                  "    pm.response.to.have.status(200);",
+                                  "});",
+                                  "",
+                                  "pm.test(\"evening15 code exists\", function () {",
+                                  "    var jsonData = pm.response.json();",
+                                  "    pm.expect(jsonData.coupon_code).to.eql(\"evening15\");",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{guest-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "GET",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts}}"
+                              ],
+                              "path": [
+                                "{{cartId}}"
+                              ]
+                            },
+                            "description": ""
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Use ?cartItemIds=",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{guest-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "DELETE",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": ""
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts_id_items}}?cartItemIds=COUPON_XXX",
+                              "host": [
+                                "{{domain}}{{endpoint_carts_id_items}}"
+                              ],
+                              "query": [
+                                {
+                                  "key": "cartItemIds",
+                                  "value": "COUPON_XXX",
+                                  "equals": true
+                                }
+                              ]
+                            },
+                            "description": ""
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Check no discount",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "var jsonData = pm.response.json();",
+                                  "pm.test(\"Status code is 200\", function () {",
+                                  "    pm.response.to.have.status(200);",
+                                  "});",
+                                  "",
+                                  "pm.test(\"Coupon code not set\", function () {",
+                                  "    pm.expect(jsonData.coupon_code).to.eql(null);",
+                                  "});",
+                                  "",
+                                  "pm.test(\"Still have items in cart\", function () {",
+                                  "    pm.expect(jsonData.items).to.be.not.empty;",
+                                  "});",
+                                  "",
+                                  ""
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{guest-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "GET",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts}}"
+                              ],
+                              "path": [
+                                "{{cartId}}"
+                              ]
+                            },
+                            "description": ""
+                          },
+                          "response": []
+                        }
+                      ],
+                      "_postman_isSubFolder": true
+                    }
+                  ],
+                  "_postman_isSubFolder": true
+                }
+              ],
+              "_postman_isSubFolder": true
+            }
+          ],
+          "_postman_isSubFolder": true
+        },
+        {
+          "name": "Mixed",
+          "description": "Adds/Removes items & coupons in one call",
+          "item": [
+            {
+              "name": "Customer",
+              "description": "",
+              "item": [
+                {
+                  "name": "Update",
+                  "description": "Run after the add tests",
+                  "item": [
+                    {
+                      "name": "Product first",
+                      "description": "",
+                      "item": [
+                        {
+                          "name": "/carts: customer",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "var jsonData = pm.response.json();",
+                                  "if (responseCode.code === 200 && jsonData.hasOwnProperty('cartId')) {",
+                                  "    pm.environment.set(\"cartId\", jsonData.cartId);",
+                                  "    tests[\"Cart ID is returned\"] = isNumeric(jsonData.cartId) === true;",
+                                  "} else {",
+                                  "    tests[\"Cart ID is not returned\"] = false;",
+                                  "}",
+                                  "",
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});",
+                                  "",
+                                  "function isNumeric(n) {",
+                                  "  return !isNaN(parseFloat(n)) && isFinite(n);",
+                                  "}"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts}}"
+                              ]
+                            },
+                            "description": "Creates a customer cart"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Add Configurable + Coupon",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "[\n  {\n    \t\"product\": {\n\t\t    \"product_id\": \"431\",\n\t\t    \"qty\": 1,\n\t\t    \"super_attribute\": {\n\t\t\t      \"92\": \"20\",\n\t\t\t      \"186\": \"102\"\n\t\t\t}\n\t\t}\n  },\n  {\n    \t\"coupon\": {\n\t\t    \"couponCode\":\"Register10\"\n\t\t}\n  }\n]"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts_id_items}}"
+                              ]
+                            },
+                            "description": "ID: 431\nType: Configurable\nName: Ann Ankle Boot\nSKU: aws005c\nURL: borgha-ankle-boot\nPrice: $470.00\nCategory: Shoes\n\n\nSub-Products:\nID: 345 | 346 | 347 | 348 | 349\nName: Ann Ankle Boot\nSKU: aws005 | aws006 | aws007 | aws008 | aws009\nColor (ID: 92): Black (ID: 20)\nShoe size (ID: 186): 6 (ID: 102) | 7 (ID: 101) | 8 (ID: 100) | 9 (ID: 99) | 10 (ID: 98)"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Check code + product",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "var jsonData = pm.response.json();",
+                                  "pm.test(\"Status code is 200\", function () {",
+                                  "    pm.response.to.have.status(200);",
+                                  "});",
+                                  "",
+                                  "pm.test(\"Register10 code exists\", function () {",
+                                  "    pm.expect(jsonData.coupon_code).to.eql(\"Register10\");",
+                                  "});",
+                                  "",
+                                  "pm.test(\"Configurable product is in cart\", function () {",
+                                  "    pm.expect(jsonData.items.length).to.be.eql(2);",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "GET",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts}}"
+                              ],
+                              "path": [
+                                "{{cartId}}"
+                              ]
+                            },
+                            "description": ""
+                          },
+                          "response": []
+                        }
+                      ],
+                      "_postman_isSubFolder": true
+                    },
+                    {
+                      "name": "Product last",
+                      "description": "",
+                      "item": [
+                        {
+                          "name": "/carts: customer",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "var jsonData = pm.response.json();",
+                                  "if (responseCode.code === 200 && jsonData.hasOwnProperty('cartId')) {",
+                                  "    pm.environment.set(\"cartId\", jsonData.cartId);",
+                                  "    tests[\"Cart ID is returned\"] = isNumeric(jsonData.cartId) === true;",
+                                  "} else {",
+                                  "    tests[\"Cart ID is not returned\"] = false;",
+                                  "}",
+                                  "",
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});",
+                                  "",
+                                  "function isNumeric(n) {",
+                                  "  return !isNaN(parseFloat(n)) && isFinite(n);",
+                                  "}"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts}}"
+                              ]
+                            },
+                            "description": "Creates a customer cart"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Add Coupon + Configurable",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test('Cannot add coupon before items are in cart', function(){",
+                                  "    pm.response.to.have.status(400);",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "[\n  {\n    \t\"coupon\": {\n\t\t    \"couponCode\":\"Register10\"\n\t\t}\n  },\n  {\n    \t\"product\": {\n\t\t    \"product_id\": \"431\",\n\t\t    \"qty\": 1,\n\t\t    \"super_attribute\": {\n\t\t\t      \"92\": \"20\",\n\t\t\t      \"186\": \"102\"\n\t\t\t}\n\t\t}\n  }\n]"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts_id_items}}"
+                              ]
+                            },
+                            "description": "ID: 431\nType: Configurable\nName: Ann Ankle Boot\nSKU: aws005c\nURL: borgha-ankle-boot\nPrice: $470.00\nCategory: Shoes\n\n\nSub-Products:\nID: 345 | 346 | 347 | 348 | 349\nName: Ann Ankle Boot\nSKU: aws005 | aws006 | aws007 | aws008 | aws009\nColor (ID: 92): Black (ID: 20)\nShoe size (ID: 186): 6 (ID: 102) | 7 (ID: 101) | 8 (ID: 100) | 9 (ID: 99) | 10 (ID: 98)"
+                          },
+                          "response": []
+                        }
+                      ],
+                      "_postman_isSubFolder": true
+                    }
+                  ],
+                  "_postman_isSubFolder": true
+                },
+                {
+                  "name": "Delete",
+                  "description": "",
+                  "item": [
+                    {
+                      "name": "Via remove all",
+                      "description": "",
+                      "item": [
+                        {
+                          "name": "/carts: customer",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "var jsonData = pm.response.json();",
+                                  "if (responseCode.code === 200 && jsonData.hasOwnProperty('cartId')) {",
+                                  "    pm.environment.set(\"cartId\", jsonData.cartId);",
+                                  "    tests[\"Cart ID is returned\"] = isNumeric(jsonData.cartId) === true;",
+                                  "} else {",
+                                  "    tests[\"Cart ID is not returned\"] = false;",
+                                  "}",
+                                  "",
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});",
+                                  "",
+                                  "function isNumeric(n) {",
+                                  "  return !isNaN(parseFloat(n)) && isFinite(n);",
+                                  "}"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts}}"
+                              ]
+                            },
+                            "description": "Creates a customer cart"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Add Configurable: Boots",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "[\n  {\n    \t\"product\": {\n\t\t    \"product_id\": \"431\",\n\t\t    \"qty\": 1,\n\t\t    \"super_attribute\": {\n\t\t\t      \"92\": \"20\",\n\t\t\t      \"186\": \"102\"\n\t\t\t}\n\t\t}\n  }\n]"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts_id_items}}"
+                              ]
+                            },
+                            "description": "ID: 431\nType: Configurable\nName: Ann Ankle Boot\nSKU: aws005c\nURL: borgha-ankle-boot\nPrice: $470.00\nCategory: Shoes\n\n\nSub-Products:\nID: 345 | 346 | 347 | 348 | 349\nName: Ann Ankle Boot\nSKU: aws005 | aws006 | aws007 | aws008 | aws009\nColor (ID: 92): Black (ID: 20)\nShoe size (ID: 186): 6 (ID: 102) | 7 (ID: 101) | 8 (ID: 100) | 9 (ID: 99) | 10 (ID: 98)"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Check no discount",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test(\"Status code is 200\", function () {",
+                                  "    pm.response.to.have.status(200);",
+                                  "});",
+                                  "",
+                                  "pm.test(\"Coupon code not set\", function () {",
+                                  "    var jsonData = pm.response.json();",
+                                  "    pm.expect(jsonData.coupon_code).to.eql(null);",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "GET",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts}}"
+                              ],
+                              "path": [
+                                "{{cartId}}"
+                              ]
+                            },
+                            "description": ""
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Add 10 flat off coupon",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "[\n  {\n    \t\"coupon\": {\n\t\t    \"couponCode\":\"Register10\"\n\t\t}\n  }\n]"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts_id_items}}"
+                              ]
+                            },
+                            "description": "Condition for coupon is Group: General, subtotal: 200+"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Check Register10 exists",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test(\"Status code is 200\", function () {",
+                                  "    pm.response.to.have.status(200);",
+                                  "});",
+                                  "",
+                                  "pm.test(\"Register10 code exists\", function () {",
+                                  "    var jsonData = pm.response.json();",
+                                  "    pm.expect(jsonData.coupon_code).to.eql(\"Register10\");",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "GET",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts}}"
+                              ],
+                              "path": [
+                                "{{cartId}}"
+                              ]
+                            },
+                            "description": ""
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Remove all items",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "DELETE",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts_id_items}}"
+                              ]
+                            },
+                            "description": ""
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Check no coupon/prods",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "var jsonData = pm.response.json();",
+                                  "pm.test(\"Status code is 200\", function () {",
+                                  "    pm.response.to.have.status(200);",
+                                  "});",
+                                  "",
+                                  "pm.test(\"Coupon code not set\", function () {",
+                                  "    pm.expect(jsonData.coupon_code).to.eql(null);",
+                                  "});",
+                                  "",
+                                  "pm.test(\"No items in cart\", function () {",
+                                  "    pm.expect(jsonData.items).to.be.empty;",
+                                  "});",
+                                  "",
+                                  ""
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "GET",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts}}"
+                              ],
+                              "path": [
+                                "{{cartId}}"
+                              ]
+                            },
+                            "description": ""
+                          },
+                          "response": []
+                        }
+                      ],
+                      "_postman_isSubFolder": true
+                    },
+                    {
+                      "name": "Via query",
+                      "description": "",
+                      "item": [
+                        {
+                          "name": "/carts: customer",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "var jsonData = pm.response.json();",
+                                  "if (responseCode.code === 200 && jsonData.hasOwnProperty('cartId')) {",
+                                  "    pm.environment.set(\"cartId\", jsonData.cartId);",
+                                  "    tests[\"Cart ID is returned\"] = isNumeric(jsonData.cartId) === true;",
+                                  "} else {",
+                                  "    tests[\"Cart ID is not returned\"] = false;",
+                                  "}",
+                                  "",
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});",
+                                  "",
+                                  "function isNumeric(n) {",
+                                  "  return !isNaN(parseFloat(n)) && isFinite(n);",
+                                  "}"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts}}"
+                              ]
+                            },
+                            "description": "Creates a customer cart"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Add Configurable: Boots",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "[\n  {\n    \t\"product\": {\n\t\t    \"product_id\": \"431\",\n\t\t    \"qty\": 1,\n\t\t    \"super_attribute\": {\n\t\t\t      \"92\": \"20\",\n\t\t\t      \"186\": \"102\"\n\t\t\t}\n\t\t}\n  }\n]"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts_id_items}}"
+                              ]
+                            },
+                            "description": "ID: 431\nType: Configurable\nName: Ann Ankle Boot\nSKU: aws005c\nURL: borgha-ankle-boot\nPrice: $470.00\nCategory: Shoes\n\n\nSub-Products:\nID: 345 | 346 | 347 | 348 | 349\nName: Ann Ankle Boot\nSKU: aws005 | aws006 | aws007 | aws008 | aws009\nColor (ID: 92): Black (ID: 20)\nShoe size (ID: 186): 6 (ID: 102) | 7 (ID: 101) | 8 (ID: 100) | 9 (ID: 99) | 10 (ID: 98)"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Check no discount",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test(\"Status code is 200\", function () {",
+                                  "    pm.response.to.have.status(200);",
+                                  "});",
+                                  "",
+                                  "pm.test(\"Coupon code not set\", function () {",
+                                  "    var jsonData = pm.response.json();",
+                                  "    pm.expect(jsonData.coupon_code).to.eql(null);",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "GET",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts}}"
+                              ],
+                              "path": [
+                                "{{cartId}}"
+                              ]
+                            },
+                            "description": ""
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Add 10 flat off coupon",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "[\n  {\n    \t\"coupon\": {\n\t\t    \"couponCode\":\"Register10\"\n\t\t}\n  }\n]"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts_id_items}}"
+                              ]
+                            },
+                            "description": "Condition for coupon is Group: General, subtotal: 200+"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Check Register10 exists",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test(\"Status code is 200\", function () {",
+                                  "    pm.response.to.have.status(200);",
+                                  "});",
+                                  "",
+                                  "pm.test(\"Register10 code exists\", function () {",
+                                  "    var jsonData = pm.response.json();",
+                                  "    pm.expect(jsonData.coupon_code).to.eql(\"Register10\");",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "GET",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts}}"
+                              ],
+                              "path": [
+                                "{{cartId}}"
+                              ]
+                            },
+                            "description": ""
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "CartItemIds > variable",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "var jsonData = pm.response.json();",
+                                  "pm.test(\"Status code is 200\", function () {",
+                                  "    pm.response.to.have.status(200);",
+                                  "});",
+                                  "",
+                                  "pm.test(\"Register10 code exists\", function () {",
+                                  "    var jsonData = pm.response.json();",
+                                  "    pm.expect(jsonData.coupon_code).to.eql(\"Register10\");",
+                                  "});",
+                                  "",
+                                  "if (responseCode.code === 200 && jsonData.items.length > 0) {",
+                                  "    var items = '';",
+                                  "    jsonData.items.forEach(function(item) {",
+                                  "        items += item.item_id + ',';",
+                                  "    });",
+                                  "    pm.environment.set(\"cart_items_to_remove\", items);",
+                                  "} else {",
+                                  "    tests[\"No cart items returned\"] = false;",
+                                  "}"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "GET",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts}}"
+                              ],
+                              "path": [
+                                "{{cartId}}"
+                              ]
+                            },
+                            "description": ""
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Add simple product",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "[\n  {\n    \"product\": {\n\t    \"product_id\": \"554\",\n\t    \"qty\": 1\n\t  }\n  }\n]"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts_id_items}}"
+                              ]
+                            },
+                            "description": "Name: Swiss Movement Sports Watch, Category: Jewelry, Price: $500.00"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Remove config + coupon",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "DELETE",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": ""
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts_id_items}}?cartItemIds={{cart_items_to_remove}}COUPON_XXX",
+                              "host": [
+                                "{{domain}}{{endpoint_carts_id_items}}"
+                              ],
+                              "query": [
+                                {
+                                  "key": "cartItemIds",
+                                  "value": "{{cart_items_to_remove}}COUPON_XXX",
+                                  "equals": true
+                                }
+                              ]
+                            },
+                            "description": "Removes configurable product + the coupon set. Leaves the Simple product intact."
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Check discount/products",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "var jsonData = pm.response.json();",
+                                  "pm.test(\"Status code is 200\", function () {",
+                                  "    pm.response.to.have.status(200);",
+                                  "});",
+                                  "",
+                                  "pm.test(\"Coupon code not set\", function () {",
+                                  "    pm.expect(jsonData.coupon_code).to.eql(null);",
+                                  "});",
+                                  "",
+                                  "pm.test(\"Still have the 544:Watch product in cart\", function () {",
+                                  "    pm.expect(jsonData.items[0].product_id).to.be.eql(\"554\");",
+                                  "});",
+                                  "",
+                                  ""
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "GET",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts}}"
+                              ],
+                              "path": [
+                                "{{cartId}}"
+                              ]
+                            },
+                            "description": "Checks that there is no coupon applied and still have items in cart"
+                          },
+                          "response": []
+                        }
+                      ],
+                      "_postman_isSubFolder": true
+                    }
+                  ],
+                  "_postman_isSubFolder": true
+                }
+              ],
+              "_postman_isSubFolder": true
+            },
+            {
+              "name": "Guest",
+              "description": "",
+              "item": [
+                {
+                  "name": "Update",
+                  "description": "",
+                  "item": [
+                    {
+                      "name": "Product first",
+                      "description": "",
+                      "item": [
+                        {
+                          "name": "/carts: guest",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "var jsonData = pm.response.json();",
+                                  "if (responseCode.code === 200 && jsonData.hasOwnProperty('cartId')) {",
+                                  "    pm.environment.set(\"cartId\", jsonData.cartId);",
+                                  "    tests[\"Cart ID is returned\"] = isNumeric(jsonData.cartId) === true;",
+                                  "} else {",
+                                  "    tests[\"Cart ID is not returned\"] = false;",
+                                  "}",
+                                  "",
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});",
+                                  "",
+                                  "function isNumeric(n) {",
+                                  "  return !isNaN(parseFloat(n)) && isFinite(n);",
+                                  "}"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{guest-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts}}"
+                              ]
+                            },
+                            "description": "Creates a guest cart and assigns the local cartId variable from the one returned"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Add config + coupon",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{guest-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "[\n  {\n\t    \"product\": {\n\t\t    \"product_id\": \"422\",\n\t\t    \"qty\": 1,\n\t\t    \"super_attribute\": {\n\t\t\t      \"92\": \"17\",\n\t\t\t      \"180\": \"76\"\n\t\t\t    }\n\t\t}\n  },\n  {\n    \t\"coupon\": {\n\t\t    \"couponCode\":\"evening15\"\n\t\t}\n  }\n]"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts_id_items}}"
+                              ]
+                            },
+                            "description": "Name: Essex Pencil Skirt; SKU: wsd000c; Category: Dresses & Skirts; Price: $185.00\nSub-Product:"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Check code + product",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "var jsonData = pm.response.json();",
+                                  "pm.test(\"Status code is 200\", function () {",
+                                  "    pm.response.to.have.status(200);",
+                                  "});",
+                                  "",
+                                  "pm.test(\"evening15 code exists\", function () {",
+                                  "    pm.expect(jsonData.coupon_code).to.eql(\"evening15\");",
+                                  "});",
+                                  "",
+                                  "pm.test(\"Configurable product is in cart\", function () {",
+                                  "    pm.expect(jsonData.items.length).to.be.eql(2);",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{guest-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "GET",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts}}"
+                              ],
+                              "path": [
+                                "{{cartId}}"
+                              ]
+                            },
+                            "description": ""
+                          },
+                          "response": []
+                        }
+                      ],
+                      "_postman_isSubFolder": true
+                    },
+                    {
+                      "name": "Product last",
+                      "description": "",
+                      "item": [
+                        {
+                          "name": "/carts: guest",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "var jsonData = pm.response.json();",
+                                  "if (responseCode.code === 200 && jsonData.hasOwnProperty('cartId')) {",
+                                  "    pm.environment.set(\"cartId\", jsonData.cartId);",
+                                  "    tests[\"Cart ID is returned\"] = isNumeric(jsonData.cartId) === true;",
+                                  "} else {",
+                                  "    tests[\"Cart ID is not returned\"] = false;",
+                                  "}",
+                                  "",
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});",
+                                  "",
+                                  "function isNumeric(n) {",
+                                  "  return !isNaN(parseFloat(n)) && isFinite(n);",
+                                  "}"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{guest-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts}}"
+                              ]
+                            },
+                            "description": "Creates a guest cart and assigns the local cartId variable from the one returned"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Add coupon + config",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test('Cannot add coupon before items are in cart', function(){",
+                                  "    pm.response.to.have.status(400);",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{guest-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "[\n  {\n    \t\"coupon\": {\n\t\t    \"couponCode\":\"evening15\"\n\t\t}\n  },\n  {\n\t    \"product\": {\n\t\t    \"product_id\": \"422\",\n\t\t    \"qty\": 1,\n\t\t    \"super_attribute\": {\n\t\t\t      \"92\": \"17\",\n\t\t\t      \"180\": \"76\"\n\t\t\t    }\n\t\t}\n  }\n]"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts_id_items}}"
+                              ]
+                            },
+                            "description": "Name: Essex Pencil Skirt; SKU: wsd000c; Category: Dresses & Skirts; Price: $185.00\nSub-Product:"
+                          },
+                          "response": []
+                        }
+                      ],
+                      "_postman_isSubFolder": true
+                    }
+                  ],
+                  "_postman_isSubFolder": true
+                },
+                {
+                  "name": "Delete",
+                  "description": "",
+                  "item": [
+                    {
+                      "name": "Via Empty All",
+                      "description": "",
+                      "item": [
+                        {
+                          "name": "/carts: guest",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "var jsonData = pm.response.json();",
+                                  "if (responseCode.code === 200 && jsonData.hasOwnProperty('cartId')) {",
+                                  "    pm.environment.set(\"cartId\", jsonData.cartId);",
+                                  "    tests[\"Cart ID is returned\"] = isNumeric(jsonData.cartId) === true;",
+                                  "} else {",
+                                  "    tests[\"Cart ID is not returned\"] = false;",
+                                  "}",
+                                  "",
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});",
+                                  "",
+                                  "function isNumeric(n) {",
+                                  "  return !isNaN(parseFloat(n)) && isFinite(n);",
+                                  "}"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{guest-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts}}"
+                              ]
+                            },
+                            "description": "Creates a guest cart and assigns the local cartId variable from the one returned"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Add Configurable: Skirt",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{guest-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "[\n  {\n\t    \"product\": {\n\t\t    \"product_id\": \"422\",\n\t\t    \"qty\": 1,\n\t\t    \"super_attribute\": {\n\t\t\t      \"92\": \"17\",\n\t\t\t      \"180\": \"76\"\n\t\t\t    }\n\t\t}\n  }\n]"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts_id_items}}"
+                              ]
+                            },
+                            "description": "ID: 422\nType: Configurable\nName: Essex Pencil Skirt\nSKU: wsd000c\nCategory: Dresses & Skirts\nPrice: $185.00\n\nSub-Products:\nID: 297 | 298 | 299 | 300 | 301\nName: Essex Pencil Skirt\nSKU: wsd000 | wsd001 | wsd002 | wsd003 | wsd004\nColor (ID: 92): Charcoal (ID: 17)\nSize (ID: 180): 2 (ID: 76) | 4 (ID: 75) | 6 (ID: 74) | 8 (ID: 73) | 10 (ID: 72)"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Check no discount",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "var jsonData = pm.response.json();",
+                                  "",
+                                  "pm.test(\"Status code is 200\", function () {",
+                                  "    pm.response.to.have.status(200);",
+                                  "});",
+                                  "",
+                                  "pm.test(\"Coupon code not set\", function () {",
+                                  "    pm.expect(jsonData.coupon_code).to.eql(null);",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{guest-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "GET",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts}}"
+                              ],
+                              "path": [
+                                "{{cartId}}"
+                              ]
+                            },
+                            "description": ""
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Add 15 flat off coupon",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{guest-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "[\n  {\n    \t\"coupon\": {\n\t\t    \"couponCode\":\"evening15\"\n\t\t}\n  }\n]"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts_id_items}}"
+                              ]
+                            },
+                            "description": "Condition for coupon is:\nGroup: Not-Logged-In, General, VIP, Private Sales Member; \nCategories: Dresses & Skirts, Dresses;"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Check evening15 exists",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test(\"Status code is 200\", function () {",
+                                  "    pm.response.to.have.status(200);",
+                                  "});",
+                                  "",
+                                  "pm.test(\"evening15 code exists\", function () {",
+                                  "    var jsonData = pm.response.json();",
+                                  "    pm.expect(jsonData.coupon_code).to.eql(\"evening15\");",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{guest-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "GET",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts}}"
+                              ],
+                              "path": [
+                                "{{cartId}}"
+                              ]
+                            },
+                            "description": ""
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Remove all items",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{guest-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "DELETE",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts_id_items}}"
+                              ]
+                            },
+                            "description": ""
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Check no prod + coupon",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "var jsonData = pm.response.json();",
+                                  "pm.test(\"Status code is 200\", function () {",
+                                  "    pm.response.to.have.status(200);",
+                                  "});",
+                                  "",
+                                  "pm.test(\"Coupon code not set\", function () {",
+                                  "    pm.expect(jsonData.coupon_code).to.eql(null);",
+                                  "});",
+                                  "",
+                                  "pm.test(\"No items in cart\", function () {",
+                                  "    pm.expect(jsonData.items).to.be.empty;",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{guest-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "GET",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts}}"
+                              ],
+                              "path": [
+                                "{{cartId}}"
+                              ]
+                            },
+                            "description": ""
+                          },
+                          "response": []
+                        }
+                      ],
+                      "_postman_isSubFolder": true
+                    },
+                    {
+                      "name": "Via query",
+                      "description": "",
+                      "item": [
+                        {
+                          "name": "/carts: guest",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "var jsonData = pm.response.json();",
+                                  "if (responseCode.code === 200 && jsonData.hasOwnProperty('cartId')) {",
+                                  "    pm.environment.set(\"cartId\", jsonData.cartId);",
+                                  "    tests[\"Cart ID is returned\"] = isNumeric(jsonData.cartId) === true;",
+                                  "} else {",
+                                  "    tests[\"Cart ID is not returned\"] = false;",
+                                  "}",
+                                  "",
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});",
+                                  "",
+                                  "function isNumeric(n) {",
+                                  "  return !isNaN(parseFloat(n)) && isFinite(n);",
+                                  "}"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{guest-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts}}"
+                              ]
+                            },
+                            "description": "Creates a guest cart and assigns the local cartId variable from the one returned"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Add Configurable: Skirt",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{guest-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "[\n  {\n\t    \"product\": {\n\t\t    \"product_id\": \"422\",\n\t\t    \"qty\": 1,\n\t\t    \"super_attribute\": {\n\t\t\t      \"92\": \"17\",\n\t\t\t      \"180\": \"76\"\n\t\t\t    }\n\t\t}\n  }\n]"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts_id_items}}"
+                              ]
+                            },
+                            "description": "ID: 422\nType: Configurable\nName: Essex Pencil Skirt\nSKU: wsd000c\nCategory: Dresses & Skirts\nPrice: $185.00\n\nSub-Products:\nID: 297 | 298 | 299 | 300 | 301\nName: Essex Pencil Skirt\nSKU: wsd000 | wsd001 | wsd002 | wsd003 | wsd004\nColor (ID: 92): Charcoal (ID: 17)\nSize (ID: 180): 2 (ID: 76) | 4 (ID: 75) | 6 (ID: 74) | 8 (ID: 73) | 10 (ID: 72)"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Check no discount",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "var jsonData = pm.response.json();",
+                                  "",
+                                  "pm.test(\"Status code is 200\", function () {",
+                                  "    pm.response.to.have.status(200);",
+                                  "});",
+                                  "",
+                                  "pm.test(\"Coupon code not set\", function () {",
+                                  "    pm.expect(jsonData.coupon_code).to.eql(null);",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{guest-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "GET",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts}}"
+                              ],
+                              "path": [
+                                "{{cartId}}"
+                              ]
+                            },
+                            "description": ""
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Add 15 flat off coupon",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{guest-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "[\n  {\n    \t\"coupon\": {\n\t\t    \"couponCode\":\"evening15\"\n\t\t}\n  }\n]"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts_id_items}}"
+                              ]
+                            },
+                            "description": "Condition for coupon is:\nGroup: Not-Logged-In, General, VIP, Private Sales Member; \nCategories: Dresses & Skirts, Dresses;"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "CartItemIds > variable",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "var jsonData = pm.response.json();",
+                                  "pm.test(\"Status code is 200\", function () {",
+                                  "    pm.response.to.have.status(200);",
+                                  "});",
+                                  "",
+                                  "pm.test(\"evening15 code exists\", function () {",
+                                  "    pm.expect(jsonData.coupon_code).to.eql(\"evening15\");",
+                                  "});",
+                                  "",
+                                  "if (responseCode.code === 200 && jsonData.items.length > 0) {",
+                                  "    var items = '';",
+                                  "    jsonData.items.forEach(function(item) {",
+                                  "        items += item.item_id + ',';",
+                                  "    });",
+                                  "    pm.environment.set(\"cart_items_to_remove\", items);",
+                                  "} else {",
+                                  "    tests[\"No cart items returned\"] = false;",
+                                  "}"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{guest-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "GET",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts}}"
+                              ],
+                              "path": [
+                                "{{cartId}}"
+                              ]
+                            },
+                            "description": ""
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Add simple product",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{guest-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "[\n  {\n    \"product\": {\n\t    \"product_id\": \"554\",\n\t    \"qty\": 1\n\t  }\n  }\n]"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts_id_items}}"
+                              ]
+                            },
+                            "description": "Name: Swiss Movement Sports Watch, Category: Jewelry, Price: $500.00"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Remove config + coupon",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{guest-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "DELETE",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": ""
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts_id_items}}?cartItemIds={{cart_items_to_remove}}COUPON_XXX",
+                              "host": [
+                                "{{domain}}{{endpoint_carts_id_items}}"
+                              ],
+                              "query": [
+                                {
+                                  "key": "cartItemIds",
+                                  "value": "{{cart_items_to_remove}}COUPON_XXX",
+                                  "equals": true
+                                }
+                              ]
+                            },
+                            "description": "Removes configurable product + the coupon set. Leaves the Simple product intact."
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Check discount/products",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "var jsonData = pm.response.json();",
+                                  "pm.test(\"Status code is 200\", function () {",
+                                  "    pm.response.to.have.status(200);",
+                                  "});",
+                                  "",
+                                  "pm.test(\"Coupon code not set\", function () {",
+                                  "    pm.expect(jsonData.coupon_code).to.eql(null);",
+                                  "});",
+                                  "",
+                                  "pm.test(\"Still have the 544:Watch product in cart\", function () {",
+                                  "    pm.expect(jsonData.items[0].product_id).to.be.eql(\"554\");",
+                                  "});",
+                                  "",
+                                  ""
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{guest-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "GET",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts}}"
+                              ],
+                              "path": [
+                                "{{cartId}}"
+                              ]
+                            },
+                            "description": "Checks that there is no coupon applied and still have items in cart"
+                          },
+                          "response": []
+                        }
+                      ],
+                      "_postman_isSubFolder": true
+                    }
+                  ],
+                  "_postman_isSubFolder": true
+                }
+              ],
+              "_postman_isSubFolder": true
+            }
+          ],
+          "_postman_isSubFolder": true
+        }
+      ]
+    },
+    {
+      "name": "/v2/carts/:id/items/:itemId",
+      "description": "",
+      "item": [
+        {
+          "name": "Product",
+          "description": "",
+          "item": [
+            {
+              "name": "Customer",
+              "description": "",
+              "item": [
+                {
+                  "name": "Update",
+                  "description": "",
+                  "item": [
+                    {
+                      "name": "Simple",
+                      "description": "",
+                      "item": [
+                        {
+                          "name": "/carts: customer",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "var jsonData = pm.response.json();",
+                                  "if (responseCode.code === 200 && jsonData.hasOwnProperty('cartId')) {",
+                                  "    pm.environment.set(\"cartId\", jsonData.cartId);",
+                                  "    tests[\"Cart ID is returned\"] = isNumeric(jsonData.cartId) === true;",
+                                  "} else {",
+                                  "    tests[\"Cart ID is not returned\"] = false;",
+                                  "}",
+                                  "",
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});",
+                                  "",
+                                  "function isNumeric(n) {",
+                                  "  return !isNaN(parseFloat(n)) && isFinite(n);",
+                                  "}"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts}}"
+                              ]
+                            },
+                            "description": "Creates a customer cart"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Add Simple",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "[\n  {\n    \"product\": {\n\t    \"product_id\": \"554\",\n\t    \"qty\": 1\n\t  }\n  }\n]"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts_me_items}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts_me_items}}"
+                              ]
+                            },
+                            "description": "ID: 554\nType: Simple\nName: Swiss Movement Sports Watch\nSKU: acj005\nURL: swiss-movement-sports-watch\nCategory: Jewelry\nPrice: $500.00\nQty: 3"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Carts: qty 1",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "var jsonData = pm.response.json();",
+                                  "if (responseCode.code === 200 && jsonData.items.length > 0) {",
+                                  "    pm.environment.set(\"cart_item_id\", jsonData.items[0].item_id);",
+                                  "} else {",
+                                  "    tests[\"Not 200 code or no cart items returned\"] = false;",
+                                  "}",
+                                  "",
+                                  "pm.test(\"Status code is 200\", function () {",
+                                  "    pm.response.to.have.status(200);",
+                                  "});",
+                                  "",
+                                  "pm.test(\"Initial quantity is 1 after adding simple product\", function () {",
+                                  "    pm.expect(jsonData.items[0].qty).to.eql(1);",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "GET",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts}}/me",
+                              "host": [
+                                "{{domain}}{{endpoint_carts}}"
+                              ],
+                              "path": [
+                                "me"
+                              ]
+                            },
+                            "description": ""
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Update simple",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{\n    \"product\": {\n\t    \"product_id\": \"554\",\n\t    \"qty\": 3\n\t  }\n}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts_me_items}}/{{cart_item_id}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts_me_items}}"
+                              ],
+                              "path": [
+                                "{{cart_item_id}}"
+                              ]
+                            },
+                            "description": "ID: 554\nType: Simple\nName: Swiss Movement Sports Watch\nSKU: acj005\nURL: swiss-movement-sports-watch\nCategory: Jewelry\nPrice: $500.00\nQty: 3"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Carts: qty 3",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test(\"Status code is 200\", function () {",
+                                  "    pm.response.to.have.status(200);",
+                                  "});",
+                                  "",
+                                  "pm.test(\"Qty is now updated to 3 for the previously inserted simple product\", function () {",
+                                  "    var jsonData = pm.response.json();",
+                                  "    pm.expect(jsonData.items[0].qty).to.eql(3);",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "GET",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts}}/me",
+                              "host": [
+                                "{{domain}}{{endpoint_carts}}"
+                              ],
+                              "path": [
+                                "me"
+                              ]
+                            },
+                            "description": ""
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Alt update",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{\n\t\"cartItemId\": \"1111\",\n    \"product\": {\n\t    \"product_id\": \"554\",\n\t    \"qty\": 4\n\t  }\n}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts_me_items}}/{{cart_item_id}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts_me_items}}"
+                              ],
+                              "path": [
+                                "{{cart_item_id}}"
+                              ]
+                            },
+                            "description": "Alternative way to updae the cart. This is the case where it is possible that the item id is in the body, even though it's not supposed to. The test makes sure the cartItemId in the body is replaced by the URI one"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Carts: qty 4",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test(\"Status code is 200\", function () {",
+                                  "    pm.response.to.have.status(200);",
+                                  "});",
+                                  "",
+                                  "pm.test(\"Qty is now updated to 4 for the previously inserted simple product\", function () {",
+                                  "    var jsonData = pm.response.json();",
+                                  "    pm.expect(jsonData.items[0].qty).to.eql(4);",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "GET",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts}}/me",
+                              "host": [
+                                "{{domain}}{{endpoint_carts}}"
+                              ],
+                              "path": [
+                                "me"
+                              ]
+                            },
+                            "description": ""
+                          },
+                          "response": []
+                        }
+                      ],
+                      "_postman_isSubFolder": true
+                    },
+                    {
+                      "name": "Configurable",
+                      "description": "",
+                      "item": [
+                        {
+                          "name": "/carts: customer",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "var jsonData = pm.response.json();",
+                                  "if (responseCode.code === 200 && jsonData.hasOwnProperty('cartId')) {",
+                                  "    pm.environment.set(\"cartId\", jsonData.cartId);",
+                                  "    tests[\"Cart ID is returned\"] = isNumeric(jsonData.cartId) === true;",
+                                  "} else {",
+                                  "    tests[\"Cart ID is not returned\"] = false;",
+                                  "}",
+                                  "",
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});",
+                                  "",
+                                  "function isNumeric(n) {",
+                                  "  return !isNaN(parseFloat(n)) && isFinite(n);",
+                                  "}"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts}}"
+                              ]
+                            },
+                            "description": "Creates a customer cart"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Add Configurable: Skirt",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "[\n  {\n\t    \"product\": {\n\t\t    \"product_id\": \"422\",\n\t\t    \"qty\": 1,\n\t\t    \"super_attribute\": {\n\t\t\t      \"92\": \"17\",\n\t\t\t      \"180\": \"76\"\n\t\t\t    }\n\t\t}\n  }\n]"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts_id_items}}"
+                              ]
+                            },
+                            "description": "ID: 422\nType: Configurable\nName: Essex Pencil Skirt\nSKU: wsd000c\nCategory: Dresses & Skirts\nPrice: $185.00\n\nSub-Products:\nID: 297 | 298 | 299 | 300 | 301\nName: Essex Pencil Skirt\nSKU: wsd000 | wsd001 | wsd002 | wsd003 | wsd004\nColor (ID: 92): Charcoal (ID: 17)\nSize (ID: 180): 2 (ID: 76) | 4 (ID: 75) | 6 (ID: 74) | 8 (ID: 73) | 10 (ID: 72)"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Carts: qty 1",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "var jsonData = pm.response.json();",
+                                  "if (responseCode.code === 200 && jsonData.items.length > 0) {",
+                                  "    pm.environment.set(\"cart_item_id\", jsonData.items[0].item_id);",
+                                  "} else {",
+                                  "    tests[\"Not 200 code or no cart items returned\"] = false;",
+                                  "}",
+                                  "",
+                                  "pm.test(\"Status code is 200\", function () {",
+                                  "    pm.response.to.have.status(200);",
+                                  "});",
+                                  "",
+                                  "pm.test(\"Initial quantity is 1 after adding simple product\", function () {",
+                                  "    pm.expect(jsonData.items[0].qty).to.eql(1);",
+                                  "    pm.expect(jsonData.items[1].qty).to.eql(1);",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "GET",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts}}/me",
+                              "host": [
+                                "{{domain}}{{endpoint_carts}}"
+                              ],
+                              "path": [
+                                "me"
+                              ]
+                            },
+                            "description": ""
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Update configurable",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{\n    \"product\": {\n\t    \"product_id\": \"422\",\n\t    \"qty\": 3\n\t}\n}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts_me_items}}/{{cart_item_id}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts_me_items}}"
+                              ],
+                              "path": [
+                                "{{cart_item_id}}"
+                              ]
+                            },
+                            "description": "ID: 554\nType: Simple\nName: Swiss Movement Sports Watch\nSKU: acj005\nURL: swiss-movement-sports-watch\nCategory: Jewelry\nPrice: $500.00\nQty: 3"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Carts: qty 3",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test(\"Status code is 200\", function () {",
+                                  "    pm.response.to.have.status(200);",
+                                  "});",
+                                  "",
+                                  "pm.test(\"Qty is now updated to 3 for the previously inserted simple product\", function () {",
+                                  "    var jsonData = pm.response.json();",
+                                  "    pm.expect(jsonData.items[0].qty).to.eql(3);",
+                                  "    pm.expect(jsonData.items[1].qty).to.eql(1);",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "GET",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts}}/me",
+                              "host": [
+                                "{{domain}}{{endpoint_carts}}"
+                              ],
+                              "path": [
+                                "me"
+                              ]
+                            },
+                            "description": ""
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Alt update",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test('Successfull call', function(){",
+                                  "    pm.response.to.be.success;",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "POST",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{\n\t\"cartItemId\": \"1111\",\n    \"product\": {\n\t    \"qty\": 4\n\t}\n}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts_me_items}}/{{cart_item_id}}",
+                              "host": [
+                                "{{domain}}{{endpoint_carts_me_items}}"
+                              ],
+                              "path": [
+                                "{{cart_item_id}}"
+                              ]
+                            },
+                            "description": "Alternative way to updae the cart. This is the case where it is possible that the item id is in the body, even though it's not supposed to. The test makes sure the cartItemId in the body is replaced by the URI one"
+                          },
+                          "response": []
+                        },
+                        {
+                          "name": "Carts: qty 4",
+                          "event": [
+                            {
+                              "listen": "test",
+                              "script": {
+                                "type": "text/javascript",
+                                "exec": [
+                                  "pm.test(\"Status code is 200\", function () {",
+                                  "    pm.response.to.have.status(200);",
+                                  "});",
+                                  "",
+                                  "pm.test(\"Qty is now updated to 4 for the previously inserted simple product\", function () {",
+                                  "    var jsonData = pm.response.json();",
+                                  "    pm.expect(jsonData.items[0].qty).to.eql(4);",
+                                  "    pm.expect(jsonData.items[1].qty).to.eql(1);",
+                                  "});"
+                                ]
+                              }
+                            }
+                          ],
+                          "request": {
+                            "auth": {
+                              "type": "bearer",
+                              "bearer": [
+                                {
+                                  "key": "token",
+                                  "value": "{{customer-access-token}}",
+                                  "type": "string"
+                                }
+                              ]
+                            },
+                            "method": "GET",
+                            "header": [
+                              {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                              }
+                            ],
+                            "body": {
+                              "mode": "raw",
+                              "raw": "{}"
+                            },
+                            "url": {
+                              "raw": "{{domain}}{{endpoint_carts}}/me",
+                              "host": [
+                                "{{domain}}{{endpoint_carts}}"
+                              ],
+                              "path": [
+                                "me"
+                              ]
+                            },
+                            "description": ""
+                          },
+                          "response": []
+                        }
+                      ],
+                      "_postman_isSubFolder": true
+                    }
+                  ],
+                  "_postman_isSubFolder": true
+                },
+                {
+                  "name": "Delete",
+                  "description": "",
+                  "item": [
+                    {
+                      "name": "/carts: customer",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "var jsonData = pm.response.json();",
+                              "if (responseCode.code === 200 && jsonData.hasOwnProperty('cartId')) {",
+                              "    pm.environment.set(\"cartId\", jsonData.cartId);",
+                              "    tests[\"Cart ID is returned\"] = isNumeric(jsonData.cartId) === true;",
+                              "} else {",
+                              "    tests[\"Cart ID is not returned\"] = false;",
+                              "}",
+                              "",
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});",
+                              "",
+                              "function isNumeric(n) {",
+                              "  return !isNaN(parseFloat(n)) && isFinite(n);",
+                              "}"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{customer-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "POST",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "{}"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts}}"
+                          ]
+                        },
+                        "description": "Creates a customer cart"
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Add Simple",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{customer-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "POST",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "[\n  {\n    \"product\": {\n\t    \"product_id\": \"554\",\n\t    \"qty\": 1\n\t  }\n  }\n]"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts_id_items}}"
+                          ]
+                        },
+                        "description": "ID: 554\nType: Simple\nName: Swiss Movement Sports Watch\nSKU: acj005\nURL: swiss-movement-sports-watch\nCategory: Jewelry\nPrice: $500.00\nQty: 3"
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Carts: qty 1",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "var jsonData = pm.response.json();",
+                              "if (responseCode.code === 200 && jsonData.items.length > 0) {",
+                              "    pm.environment.set(\"cart_item_id\", jsonData.items[0].item_id);",
+                              "} else {",
+                              "    tests[\"Not 200 code or no cart items returned\"] = false;",
+                              "}",
+                              "",
+                              "pm.test(\"Status code is 200\", function () {",
+                              "    pm.response.to.have.status(200);",
+                              "});",
+                              "",
+                              "pm.test(\"Initial quantity is 1 after adding simple product\", function () {",
+                              "    pm.expect(jsonData.items.length).to.eql(1);",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{customer-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "GET",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "{}"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts}}"
+                          ],
+                          "path": [
+                            "{{cartId}}"
+                          ]
+                        },
+                        "description": ""
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Delete by ID",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{customer-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "DELETE",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": ""
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts_id_items}}/{{cart_item_id}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts_id_items}}"
+                          ],
+                          "path": [
+                            "{{cart_item_id}}"
+                          ]
+                        },
+                        "description": ""
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Check cart for no items",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test(\"Status code is 200\", function () {",
+                              "    pm.response.to.have.status(200);",
+                              "});",
+                              "",
+                              "pm.test(\"No items in cart\", function () {",
+                              "    var jsonData = pm.response.json();",
+                              "    pm.expect(jsonData.items).to.be.empty;",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{customer-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "GET",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "{}"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts}}"
+                          ],
+                          "path": [
+                            "{{cartId}}"
+                          ]
+                        },
+                        "description": ""
+                      },
+                      "response": []
+                    }
+                  ],
+                  "_postman_isSubFolder": true
+                }
+              ],
+              "_postman_isSubFolder": true
+            },
+            {
+              "name": "Guest",
+              "description": "",
+              "item": [
+                {
+                  "name": "Update",
+                  "description": "",
+                  "item": [
+                    {
+                      "name": "/carts: Guest Cart",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "var jsonData = pm.response.json();",
+                              "if (responseCode.code === 200 && jsonData.hasOwnProperty('cartId')) {",
+                              "    pm.environment.set(\"cartId\", jsonData.cartId);",
+                              "    tests[\"Cart ID is returned\"] = isNumeric(jsonData.cartId) === true;",
+                              "} else {",
+                              "    tests[\"Cart ID is not returned\"] = false;",
+                              "}",
+                              "",
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});",
+                              "",
+                              "function isNumeric(n) {",
+                              "  return !isNaN(parseFloat(n)) && isFinite(n);",
+                              "}"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{guest-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "POST",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "{}"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts}}"
+                          ]
+                        },
+                        "description": "Creates a guest cart and assigns the local cartId variable from the one returned"
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Add Simple",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{guest-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "POST",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "[\n  {\n    \"product\": {\n\t    \"product_id\": \"554\",\n\t    \"qty\": 1\n\t  }\n  }\n]"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts_id_items}}"
+                          ]
+                        },
+                        "description": "ID: 554\nType: Simple\nName: Swiss Movement Sports Watch\nSKU: acj005\nURL: swiss-movement-sports-watch\nCategory: Jewelry\nPrice: $500.00\nQty: 3"
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Carts: qty 1",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "var jsonData = pm.response.json();",
+                              "if (responseCode.code === 200 && jsonData.items.length > 0) {",
+                              "    pm.environment.set(\"cart_item_id\", jsonData.items[0].item_id);",
+                              "} else {",
+                              "    tests[\"Not 200 code or no cart items returned\"] = false;",
+                              "}",
+                              "",
+                              "pm.test(\"Status code is 200\", function () {",
+                              "    pm.response.to.have.status(200);",
+                              "});",
+                              "",
+                              "pm.test(\"Initial quantity is 1 after adding simple product\", function () {",
+                              "    pm.expect(jsonData.items[0].qty).to.eql(1);",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{guest-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "GET",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "{}"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts}}"
+                          ],
+                          "path": [
+                            "{{cartId}}"
+                          ]
+                        },
+                        "description": "Creates a customer cart"
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Update (no cartItem)",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{guest-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "POST",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "{\n    \"product\": {\n\t    \"product_id\": \"554\",\n\t    \"qty\": 3\n\t  }\n}"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts_id_items}}/{{cart_item_id}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts_id_items}}"
+                          ],
+                          "path": [
+                            "{{cart_item_id}}"
+                          ]
+                        },
+                        "description": "Physical Gift Card"
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Carts: qty 3",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test(\"Status code is 200\", function () {",
+                              "    pm.response.to.have.status(200);",
+                              "});",
+                              "",
+                              "pm.test(\"Qty is now updated to 3 for the previously inserted simple product\", function () {",
+                              "    var jsonData = pm.response.json();",
+                              "    pm.expect(jsonData.items[0].qty).to.eql(3);",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{guest-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "GET",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "{}"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts}}"
+                          ],
+                          "path": [
+                            "{{cartId}}"
+                          ]
+                        },
+                        "description": "Creates a customer cart"
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Alt update",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{guest-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "POST",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "{\n\t\"cartItemId\": \"1111\",\n    \"product\": {\n\t    \"product_id\": \"554\",\n\t    \"qty\": 4\n\t  }\n}"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts_id_items}}/{{cart_item_id}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts_id_items}}"
+                          ],
+                          "path": [
+                            "{{cart_item_id}}"
+                          ]
+                        },
+                        "description": "Alternative way to updae the cart. This is the case where it is possible that the item id is in the body, even though it's not supposed to. The test makes sure the cartItemId in the body is replaced by the URI one"
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Carts: qty 4",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test(\"Status code is 200\", function () {",
+                              "    pm.response.to.have.status(200);",
+                              "});",
+                              "",
+                              "pm.test(\"Qty is now updated to 4 for the previously inserted simple product\", function () {",
+                              "    var jsonData = pm.response.json();",
+                              "    pm.expect(jsonData.items[0].qty).to.eql(4);",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{guest-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "GET",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "{}"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts}}"
+                          ],
+                          "path": [
+                            "{{cartId}}"
+                          ]
+                        },
+                        "description": "Creates a customer cart"
+                      },
+                      "response": []
+                    }
+                  ],
+                  "_postman_isSubFolder": true
+                },
+                {
+                  "name": "Delete",
+                  "description": "",
+                  "item": [
+                    {
+                      "name": "/carts: Guest Cart",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "var jsonData = pm.response.json();",
+                              "if (responseCode.code === 200 && jsonData.hasOwnProperty('cartId')) {",
+                              "    pm.environment.set(\"cartId\", jsonData.cartId);",
+                              "    tests[\"Cart ID is returned\"] = isNumeric(jsonData.cartId) === true;",
+                              "} else {",
+                              "    tests[\"Cart ID is not returned\"] = false;",
+                              "}",
+                              "",
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});",
+                              "",
+                              "function isNumeric(n) {",
+                              "  return !isNaN(parseFloat(n)) && isFinite(n);",
+                              "}"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{guest-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "POST",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "{}"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts}}"
+                          ]
+                        },
+                        "description": "Creates a guest cart and assigns the local cartId variable from the one returned"
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Add Simple",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{guest-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "POST",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "[\n  {\n    \"product\": {\n\t    \"product_id\": \"554\",\n\t    \"qty\": 1\n\t  }\n  }\n]"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts_id_items}}"
+                          ]
+                        },
+                        "description": "ID: 554\nType: Simple\nName: Swiss Movement Sports Watch\nSKU: acj005\nURL: swiss-movement-sports-watch\nCategory: Jewelry\nPrice: $500.00\nQty: 3"
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Carts: qty 1",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "var jsonData = pm.response.json();",
+                              "if (responseCode.code === 200 && jsonData.items.length > 0) {",
+                              "    pm.environment.set(\"cart_item_id\", jsonData.items[0].item_id);",
+                              "} else {",
+                              "    tests[\"Not 200 code or no cart items returned\"] = false;",
+                              "}",
+                              "",
+                              "pm.test(\"Status code is 200\", function () {",
+                              "    pm.response.to.have.status(200);",
+                              "});",
+                              "",
+                              "pm.test(\"Initial quantity is 1 after adding simple product\", function () {",
+                              "    pm.expect(jsonData.items.length).to.eql(1);",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{guest-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "GET",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "{}"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts}}"
+                          ],
+                          "path": [
+                            "{{cartId}}"
+                          ]
+                        },
+                        "description": ""
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Delete by ID",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{guest-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "DELETE",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": ""
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts_id_items}}/{{cart_item_id}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts_id_items}}"
+                          ],
+                          "path": [
+                            "{{cart_item_id}}"
+                          ]
+                        },
+                        "description": ""
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Check cart for no items",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test(\"Status code is 200\", function () {",
+                              "    pm.response.to.have.status(200);",
+                              "});",
+                              "",
+                              "pm.test(\"No items in cart\", function () {",
+                              "    var jsonData = pm.response.json();",
+                              "    pm.expect(jsonData.items).to.be.empty;",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{guest-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "GET",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "{}"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts}}"
+                          ],
+                          "path": [
+                            "{{cartId}}"
+                          ]
+                        },
+                        "description": ""
+                      },
+                      "response": []
+                    }
+                  ],
+                  "_postman_isSubFolder": true
+                }
+              ],
+              "_postman_isSubFolder": true
+            }
+          ],
+          "_postman_isSubFolder": true
+        },
+        {
+          "name": "Coupon",
+          "description": "",
+          "item": [
+            {
+              "name": "Customer",
+              "description": "",
+              "item": [
+                {
+                  "name": "Delete",
+                  "description": "",
+                  "item": [
+                    {
+                      "name": "/carts: customer",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "var jsonData = pm.response.json();",
+                              "if (responseCode.code === 200 && jsonData.hasOwnProperty('cartId')) {",
+                              "    pm.environment.set(\"cartId\", jsonData.cartId);",
+                              "    tests[\"Cart ID is returned\"] = isNumeric(jsonData.cartId) === true;",
+                              "} else {",
+                              "    tests[\"Cart ID is not returned\"] = false;",
+                              "}",
+                              "",
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});",
+                              "",
+                              "function isNumeric(n) {",
+                              "  return !isNaN(parseFloat(n)) && isFinite(n);",
+                              "}"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{customer-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "POST",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "{}"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts}}"
+                          ]
+                        },
+                        "description": "Creates a customer cart"
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Add Configurable: Boots",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{customer-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "POST",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "[\n  {\n    \t\"product\": {\n\t\t    \"product_id\": \"431\",\n\t\t    \"qty\": 1,\n\t\t    \"super_attribute\": {\n\t\t\t      \"92\": \"20\",\n\t\t\t      \"186\": \"102\"\n\t\t\t}\n\t\t}\n  }\n]"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts_id_items}}"
+                          ]
+                        },
+                        "description": "ID: 431\nType: Configurable\nName: Ann Ankle Boot\nSKU: aws005c\nURL: borgha-ankle-boot\nPrice: $470.00\nCategory: Shoes\n\n\nSub-Products:\nID: 345 | 346 | 347 | 348 | 349\nName: Ann Ankle Boot\nSKU: aws005 | aws006 | aws007 | aws008 | aws009\nColor (ID: 92): Black (ID: 20)\nShoe size (ID: 186): 6 (ID: 102) | 7 (ID: 101) | 8 (ID: 100) | 9 (ID: 99) | 10 (ID: 98)"
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Add 10 flat off coupon",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{customer-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "POST",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "[\n  {\n    \t\"coupon\": {\n\t\t    \"couponCode\":\"Register10\"\n\t\t}\n  }\n]"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts_id_items}}"
+                          ]
+                        },
+                        "description": "Condition for coupon is Group: General, subtotal: 200+"
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Check Register10 exists",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test(\"Status code is 200\", function () {",
+                              "    pm.response.to.have.status(200);",
+                              "});",
+                              "",
+                              "pm.test(\"Register10 code exists\", function () {",
+                              "    var jsonData = pm.response.json();",
+                              "    pm.expect(jsonData.coupon_code).to.eql(\"Register10\");",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{customer-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "GET",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "{}"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts}}"
+                          ],
+                          "path": [
+                            "{{cartId}}"
+                          ]
+                        },
+                        "description": ""
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "items/COUPON_X",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{customer-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "DELETE",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": ""
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts_id_items}}/COUPON_XXX",
+                          "host": [
+                            "{{domain}}{{endpoint_carts_id_items}}"
+                          ],
+                          "path": [
+                            "COUPON_XXX"
+                          ]
+                        },
+                        "description": "Removes configurable product + the coupon set. Leaves the Simple product intact."
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Check discount/products",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "var jsonData = pm.response.json();",
+                              "pm.test(\"Status code is 200\", function () {",
+                              "    pm.response.to.have.status(200);",
+                              "});",
+                              "",
+                              "pm.test(\"Coupon code not set\", function () {",
+                              "    pm.expect(jsonData.coupon_code).to.eql(null);",
+                              "});",
+                              "",
+                              "pm.test(\"Still have configurable products in cart\", function () {",
+                              "    pm.expect(jsonData.items.length).to.be.eql(2);",
+                              "});",
+                              "",
+                              ""
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{customer-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "GET",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "{}"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts}}"
+                          ],
+                          "path": [
+                            "{{cartId}}"
+                          ]
+                        },
+                        "description": "Checks that there is no coupon applied and still have items in cart"
+                      },
+                      "response": []
+                    }
+                  ],
+                  "_postman_isSubFolder": true
+                }
+              ],
+              "_postman_isSubFolder": true
+            },
+            {
+              "name": "Guest",
+              "description": "",
+              "item": [
+                {
+                  "name": "Delete",
+                  "description": "",
+                  "item": [
+                    {
+                      "name": "/carts: guest",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "var jsonData = pm.response.json();",
+                              "if (responseCode.code === 200 && jsonData.hasOwnProperty('cartId')) {",
+                              "    pm.environment.set(\"cartId\", jsonData.cartId);",
+                              "    tests[\"Cart ID is returned\"] = isNumeric(jsonData.cartId) === true;",
+                              "} else {",
+                              "    tests[\"Cart ID is not returned\"] = false;",
+                              "}",
+                              "",
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});",
+                              "",
+                              "function isNumeric(n) {",
+                              "  return !isNaN(parseFloat(n)) && isFinite(n);",
+                              "}"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{guest-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "POST",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "{}"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts}}"
+                          ]
+                        },
+                        "description": "Creates a guest cart and assigns the local cartId variable from the one returned"
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Add Configurable: Skirt",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{guest-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "POST",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "[\n  {\n\t    \"product\": {\n\t\t    \"product_id\": \"422\",\n\t\t    \"qty\": 1,\n\t\t    \"super_attribute\": {\n\t\t\t      \"92\": \"17\",\n\t\t\t      \"180\": \"76\"\n\t\t\t    }\n\t\t}\n  }\n]"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts_id_items}}"
+                          ]
+                        },
+                        "description": "ID: 422\nType: Configurable\nName: Essex Pencil Skirt\nSKU: wsd000c\nCategory: Dresses & Skirts\nPrice: $185.00\n\nSub-Products:\nID: 297 | 298 | 299 | 300 | 301\nName: Essex Pencil Skirt\nSKU: wsd000 | wsd001 | wsd002 | wsd003 | wsd004\nColor (ID: 92): Charcoal (ID: 17)\nSize (ID: 180): 2 (ID: 76) | 4 (ID: 75) | 6 (ID: 74) | 8 (ID: 73) | 10 (ID: 72)"
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Add 15 flat off coupon",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{guest-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "POST",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "[\n  {\n    \t\"coupon\": {\n\t\t    \"couponCode\":\"evening15\"\n\t\t}\n  }\n]"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts_id_items}}"
+                          ]
+                        },
+                        "description": "Condition for coupon is:\nGroup: Not-Logged-In, General, VIP, Private Sales Member; \nCategories: Dresses & Skirts, Dresses;"
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Code evening15 exists",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "var jsonData = pm.response.json();",
+                              "pm.test(\"Status code is 200\", function () {",
+                              "    pm.response.to.have.status(200);",
+                              "});",
+                              "",
+                              "pm.test(\"evening15 code exists\", function () {",
+                              "    pm.expect(jsonData.coupon_code).to.eql(\"evening15\");",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{guest-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "GET",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "{}"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts}}"
+                          ],
+                          "path": [
+                            "{{cartId}}"
+                          ]
+                        },
+                        "description": ""
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "items/COUPON_X",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "pm.test('Successfull call', function(){",
+                              "    pm.response.to.be.success;",
+                              "});"
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{guest-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "DELETE",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": ""
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts_id_items}}/COUPON_XXX",
+                          "host": [
+                            "{{domain}}{{endpoint_carts_id_items}}"
+                          ],
+                          "path": [
+                            "COUPON_XXX"
+                          ]
+                        },
+                        "description": "Removes configurable product + the coupon set. Leaves the Simple product intact."
+                      },
+                      "response": []
+                    },
+                    {
+                      "name": "Check discount/products",
+                      "event": [
+                        {
+                          "listen": "test",
+                          "script": {
+                            "type": "text/javascript",
+                            "exec": [
+                              "var jsonData = pm.response.json();",
+                              "pm.test(\"Status code is 200\", function () {",
+                              "    pm.response.to.have.status(200);",
+                              "});",
+                              "",
+                              "pm.test(\"Coupon code not set\", function () {",
+                              "    pm.expect(jsonData.coupon_code).to.eql(null);",
+                              "});",
+                              "",
+                              "pm.test(\"Still have configurable item in cart\", function () {",
+                              "    pm.expect(jsonData.items.length).to.be.eql(2);",
+                              "});",
+                              "",
+                              ""
+                            ]
+                          }
+                        }
+                      ],
+                      "request": {
+                        "auth": {
+                          "type": "bearer",
+                          "bearer": [
+                            {
+                              "key": "token",
+                              "value": "{{guest-access-token}}",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "method": "GET",
+                        "header": [
+                          {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                          }
+                        ],
+                        "body": {
+                          "mode": "raw",
+                          "raw": "{}"
+                        },
+                        "url": {
+                          "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                          "host": [
+                            "{{domain}}{{endpoint_carts}}"
+                          ],
+                          "path": [
+                            "{{cartId}}"
+                          ]
+                        },
+                        "description": "Checks that there is no coupon applied and still have items in cart"
+                      },
+                      "response": []
+                    }
+                  ],
+                  "_postman_isSubFolder": true
+                }
+              ],
+              "_postman_isSubFolder": true
+            }
+          ],
+          "_postman_isSubFolder": true
+        }
+      ]
+    },
+    {
+      "name": "/v2/carts/:id/checkoutUrl",
+      "description": "",
+      "item": [
+        {
+          "name": "Customer",
+          "description": "",
+          "item": [
+            {
+              "name": "Create customer cart",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "var jsonData = pm.response.json();",
+                      "if (responseCode.code === 200 && jsonData.hasOwnProperty('cartId')) {",
+                      "    pm.environment.set(\"cartId\", jsonData.cartId);",
+                      "    tests[\"Cart ID is returned\"] = isNumeric(jsonData.cartId) === true;",
+                      "} else {",
+                      "    tests[\"Cart ID is not returned\"] = false;",
+                      "}",
+                      "",
+                      "pm.test('Successfull call', function(){",
+                      "    pm.response.to.be.success;",
+                      "});",
+                      "",
+                      "function isNumeric(n) {",
+                      "  return !isNaN(parseFloat(n)) && isFinite(n);",
+                      "}"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{customer-access-token}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{}"
+                },
+                "url": {
+                  "raw": "{{domain}}{{endpoint_carts}}",
+                  "host": [
+                    "{{domain}}{{endpoint_carts}}"
+                  ]
+                },
+                "description": "Creates a customer cart"
+              },
+              "response": []
+            },
+            {
+              "name": "Add simple product to cart",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test('Successfull call', function(){",
+                      "    pm.response.to.be.success;",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{customer-access-token}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "[\n  {\n    \"product\": {\n\t    \"product_id\": \"554\",\n\t    \"qty\": 1\n\t  }\n  }\n]"
+                },
+                "url": {
+                  "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                  "host": [
+                    "{{domain}}{{endpoint_carts_id_items}}"
+                  ]
+                },
+                "description": "ID: 554\nType: Simple\nName: Swiss Movement Sports Watch\nSKU: acj005\nURL: swiss-movement-sports-watch\nCategory: Jewelry\nPrice: $500.00\nQty: 3"
+              },
+              "response": []
+            },
+            {
+              "name": "checkoutURL",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});",
+                      "",
+                      "pm.test(\"Checkout URL is returned\", function () {",
+                      "    var jsonData = pm.response.json();",
+                      "    pm.response.to.have.jsonBody('url');",
+                      "    pm.response.to.have.jsonBody('expires_in', 30);",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{customer-access-token}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{}"
+                },
+                "url": {
+                  "raw": "{{domain}}{{endpoint_carts_id_checkoutUrl}}",
+                  "host": [
+                    "{{domain}}{{endpoint_carts_id_checkoutUrl}}"
+                  ]
+                },
+                "description": ""
+              },
+              "response": []
+            }
+          ],
+          "_postman_isSubFolder": true
+        },
+        {
+          "name": "Guest",
+          "description": "",
+          "item": [
+            {
+              "name": "Create guest cart",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "var jsonData = pm.response.json();",
+                      "if (responseCode.code === 200 && jsonData.hasOwnProperty('cartId')) {",
+                      "    pm.environment.set(\"cartId\", jsonData.cartId);",
+                      "    tests[\"Cart ID is returned\"] = isNumeric(jsonData.cartId) === true;",
+                      "} else {",
+                      "    tests[\"Cart ID is not returned\"] = false;",
+                      "}",
+                      "",
+                      "pm.test('Successfull call', function(){",
+                      "    pm.response.to.be.success;",
+                      "});",
+                      "",
+                      "function isNumeric(n) {",
+                      "  return !isNaN(parseFloat(n)) && isFinite(n);",
+                      "}"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{guest-access-token}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{}"
+                },
+                "url": {
+                  "raw": "{{domain}}{{endpoint_carts}}",
+                  "host": [
+                    "{{domain}}{{endpoint_carts}}"
+                  ]
+                },
+                "description": "Creates a guest cart and assigns the local cartId variable from the one returned"
+              },
+              "response": []
+            },
+            {
+              "name": "Add simple item to cart",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test('Successfull call', function(){",
+                      "    pm.response.to.be.success;",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{guest-access-token}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "[\n  {\n    \"product\": {\n\t    \"product_id\": \"554\",\n\t    \"qty\": 1\n\t  }\n  }\n]"
+                },
+                "url": {
+                  "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                  "host": [
+                    "{{domain}}{{endpoint_carts_id_items}}"
+                  ]
+                },
+                "description": "ID: 554\nType: Simple\nName: Swiss Movement Sports Watch\nSKU: acj005\nURL: swiss-movement-sports-watch\nCategory: Jewelry\nPrice: $500.00\nQty: 3"
+              },
+              "response": []
+            },
+            {
+              "name": "checkoutURL",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});",
+                      "",
+                      "pm.test(\"Checkout URL is returned\", function () {",
+                      "    var jsonData = pm.response.json();",
+                      "    pm.response.to.have.jsonBody('url');",
+                      "    pm.response.to.have.jsonBody('expires_in', 30);",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{guest-access-token}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{}"
+                },
+                "url": {
+                  "raw": "{{domain}}{{endpoint_carts_id_checkoutUrl}}",
+                  "host": [
+                    "{{domain}}{{endpoint_carts_id_checkoutUrl}}"
+                  ]
+                },
+                "description": ""
+              },
+              "response": []
+            }
+          ],
+          "_postman_isSubFolder": true
+        }
+      ]
+    },
+    {
+      "name": "/v2/carts/:id/customer",
+      "description": "",
+      "item": [
+        {
+          "name": "Create customer cart",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var jsonData = pm.response.json();",
+                  "if (responseCode.code === 200 && jsonData.hasOwnProperty('cartId')) {",
+                  "    pm.environment.set(\"cartId\", jsonData.cartId);",
+                  "    tests[\"Cart ID is returned\"] = isNumeric(jsonData.cartId) === true;",
+                  "} else {",
+                  "    tests[\"Cart ID is not returned\"] = false;",
+                  "}",
+                  "",
+                  "pm.test('Successfull call', function(){",
+                  "    pm.response.to.be.success;",
+                  "});",
+                  "",
+                  "function isNumeric(n) {",
+                  "  return !isNaN(parseFloat(n)) && isFinite(n);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{customer-access-token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            },
+            "url": {
+              "raw": "{{domain}}{{endpoint_carts}}",
+              "host": [
+                "{{domain}}{{endpoint_carts}}"
+              ]
+            },
+            "description": "Creates a customer cart"
+          },
+          "response": []
+        },
+        {
+          "name": "Customer: add simple",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Successfull call', function(){",
+                  "    pm.response.to.be.success;",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{customer-access-token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "[\n  {\n    \"product\": {\n\t    \"product_id\": \"554\",\n\t    \"qty\": 1\n\t  }\n  }\n]"
+            },
+            "url": {
+              "raw": "{{domain}}{{endpoint_carts_id_items}}",
+              "host": [
+                "{{domain}}{{endpoint_carts_id_items}}"
+              ]
+            },
+            "description": "ID: 554\nType: Simple\nName: Swiss Movement Sports Watch\nSKU: acj005\nURL: swiss-movement-sports-watch\nCategory: Jewelry\nPrice: $500.00\nQty: 3"
+          },
+          "response": []
+        },
+        {
+          "name": "Customer: cart qty 1",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var jsonData = pm.response.json();",
+                  "",
+                  "pm.test(\"Status code is 200\", function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test(\"Initial quantity is 1 after adding a simple product\", function () {",
+                  "    pm.expect(jsonData.items.length).to.eql(1);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{customer-access-token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            },
+            "url": {
+              "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+              "host": [
+                "{{domain}}{{endpoint_carts}}"
+              ],
+              "path": [
+                "{{cartId}}"
+              ]
+            },
+            "description": "Creates a customer cart"
+          },
+          "response": []
+        },
+        {
+          "name": "/carts: Guest Cart",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var jsonData = pm.response.json();",
+                  "if (responseCode.code === 200 && jsonData.hasOwnProperty('cartId')) {",
+                  "    pm.environment.set(\"cartId\", jsonData.cartId);",
+                  "    tests[\"Cart ID is returned\"] = isNumeric(jsonData.cartId) === true;",
+                  "} else {",
+                  "    tests[\"Cart ID is not returned\"] = false;",
+                  "}",
+                  "",
+                  "pm.test('Successfull call', function(){",
+                  "    pm.response.to.be.success;",
+                  "});",
+                  "",
+                  "function isNumeric(n) {",
+                  "  return !isNaN(parseFloat(n)) && isFinite(n);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{guest-access-token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            },
+            "url": {
+              "raw": "{{domain}}{{endpoint_carts}}",
+              "host": [
+                "{{domain}}{{endpoint_carts}}"
+              ]
+            },
+            "description": "Creates a guest cart and assigns the local cartId variable from the one returned"
+          },
+          "response": []
+        },
+        {
+          "name": "Guest: add downloadable",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Successfull call', function(){",
+                  "    pm.response.to.be.success;",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{guest-access-token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "[\n  {\n    \"product\": {\n\t    \"product_id\": \"563\",\n\t    \"qty\": 1,\n\t    \"links\": [\n\t      \"18\"\n\t    ]\n\t }\n  }\n]"
+            },
+            "url": {
+              "raw": "{{domain}}{{endpoint_carts_id_items}}",
+              "host": [
+                "{{domain}}{{endpoint_carts_id_items}}"
+              ]
+            },
+            "description": "ID: 563\nName: Fire [Kalima remix] by Unannounced Guest\nSKU: hbm010\nCategory: Music & Books\nURL: fire-kalima-remix-by-unannounced-guest\nPrice: 2.00\nQty: 1000"
+          },
+          "response": []
+        },
+        {
+          "name": "Guest: cart qty 1",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var jsonData = pm.response.json();",
+                  "",
+                  "pm.test(\"Status code is 200\", function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test(\"Initial quantity is 1 after adding a downlodable product\", function () {",
+                  "    pm.expect(jsonData.items.length).to.eql(1);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{guest-access-token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            },
+            "url": {
+              "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+              "host": [
+                "{{domain}}{{endpoint_carts}}"
+              ],
+              "path": [
+                "{{cartId}}"
+              ]
+            },
+            "description": "calls a customer cart as guest"
+          },
+          "response": []
+        },
+        {
+          "name": "Merge carts",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var jsonData = pm.response.json();",
+                  "if (responseCode.code === 200 && jsonData.cartId) {",
+                  "    pm.environment.set(\"cartId\", jsonData.cartId);",
+                  "}",
+                  "",
+                  "pm.test(\"Status code is 200\", function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test(\"Cart ID is returned\", function () {",
+                  "    pm.expect(jsonData.cartId).to.not.be.empty;",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{customer-access-token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            },
+            "url": {
+              "raw": "{{domain}}{{endpoint_carts_id_customer}}",
+              "host": [
+                "{{domain}}{{endpoint_carts_id_customer}}"
+              ]
+            },
+            "description": ""
+          },
+          "response": []
+        },
+        {
+          "name": "Customer: cart qty 2",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var jsonData = pm.response.json();",
+                  "",
+                  "pm.test(\"Status code is 200\", function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test(\"Carts merged, 2 items in cart\", function () {",
+                  "    pm.expect(jsonData.items.length).to.eql(2);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{customer-access-token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            },
+            "url": {
+              "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+              "host": [
+                "{{domain}}{{endpoint_carts}}"
+              ],
+              "path": [
+                "{{cartId}}"
+              ]
+            },
+            "description": "Creates a customer cart"
+          },
+          "response": []
+        },
+        {
+          "name": "Merge: call ME endpoint",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(\"Cannot use ME endpoint here\", function () {",
+                  "    pm.response.to.have.status(400);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{customer-access-token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            },
+            "url": {
+              "raw": "{{domain}}{{endpoint_carts}}/me/customer",
+              "host": [
+                "{{domain}}{{endpoint_carts}}"
+              ],
+              "path": [
+                "me",
+                "customer"
+              ]
+            },
+            "description": ""
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "/v2/products",
+      "description": "",
+      "item": [
+        {
+          "name": "Customer",
+          "description": "",
+          "item": [
+            {
+              "name": "No limit",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});",
+                      "",
+                      "pm.test(\"Retrieved 10 products when no limits are applied\", function () {",
+                      "    var jsonData = pm.response.json();",
+                      "    var count = Object.keys(jsonData).length;",
+                      "    pm.expect(count).to.eql(10);",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{customer-access-token}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {},
+                "url": {
+                  "raw": "{{domain}}{{endpoint_products}}",
+                  "host": [
+                    "{{domain}}{{endpoint_products}}"
+                  ]
+                },
+                "description": ""
+              },
+              "response": []
+            },
+            {
+              "name": "Category - New Arrivals",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});",
+                      "",
+                      "pm.test(\"Retrieved 3 products from New Arrivals category\", function () {",
+                      "    var jsonData = pm.response.json();",
+                      "    var count = Object.keys(jsonData).length;",
+                      "    pm.expect(count).to.eql(3);",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{customer-access-token}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {},
+                "url": {
+                  "raw": "{{domain}}{{endpoint_products}}?category_id=10",
+                  "host": [
+                    "{{domain}}{{endpoint_products}}"
+                  ],
+                  "query": [
+                    {
+                      "key": "category_id",
+                      "value": "10",
+                      "equals": true
+                    }
+                  ]
+                },
+                "description": ""
+              },
+              "response": []
+            },
+            {
+              "name": "Category - does not exist",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Get category does not exist error\", function () {",
+                      "    pm.response.to.have.status(400);",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{customer-access-token}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {},
+                "url": {
+                  "raw": "{{domain}}{{endpoint_products}}?category_id=99999",
+                  "host": [
+                    "{{domain}}{{endpoint_products}}"
+                  ],
+                  "query": [
+                    {
+                      "key": "category_id",
+                      "value": "99999",
+                      "equals": true
+                    }
+                  ]
+                },
+                "description": ""
+              },
+              "response": []
+            },
+            {
+              "name": "Page 1, Limit 4",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});",
+                      "",
+                      "pm.test(\"Retrieved 3 products from New Arrivals category\", function () {",
+                      "    var jsonData = pm.response.json();",
+                      "    var count = Object.keys(jsonData).length;",
+                      "    pm.expect(count).to.eql(4);",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{customer-access-token}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {},
+                "url": {
+                  "raw": "{{domain}}{{endpoint_products}}?page=1&limit=4",
+                  "host": [
+                    "{{domain}}{{endpoint_products}}"
+                  ],
+                  "query": [
+                    {
+                      "key": "page",
+                      "value": "1",
+                      "equals": true
+                    },
+                    {
+                      "key": "limit",
+                      "value": "4",
+                      "equals": true
+                    }
+                  ]
+                },
+                "description": ""
+              },
+              "response": []
+            }
+          ],
+          "_postman_isSubFolder": true
+        },
+        {
+          "name": "Guest",
+          "description": "",
+          "item": [
+            {
+              "name": "No limit",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});",
+                      "",
+                      "pm.test(\"Retrieved 10 products when no limits are applied\", function () {",
+                      "    var jsonData = pm.response.json();",
+                      "    var count = Object.keys(jsonData).length;",
+                      "    pm.expect(count).to.eql(10);",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{guest-access-token}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {},
+                "url": {
+                  "raw": "{{domain}}{{endpoint_products}}",
+                  "host": [
+                    "{{domain}}{{endpoint_products}}"
+                  ]
+                },
+                "description": ""
+              },
+              "response": []
+            },
+            {
+              "name": "Category - New Arrivals",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});",
+                      "",
+                      "pm.test(\"Retrieved 3 products from New Arrivals category\", function () {",
+                      "    var jsonData = pm.response.json();",
+                      "    var count = Object.keys(jsonData).length;",
+                      "    pm.expect(count).to.eql(3);",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{guest-access-token}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {},
+                "url": {
+                  "raw": "{{domain}}{{endpoint_products}}?category_id=10",
+                  "host": [
+                    "{{domain}}{{endpoint_products}}"
+                  ],
+                  "query": [
+                    {
+                      "key": "category_id",
+                      "value": "10",
+                      "equals": true
+                    }
+                  ]
+                },
+                "description": ""
+              },
+              "response": []
+            },
+            {
+              "name": "Category - does not exist",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Get category does not exist error\", function () {",
+                      "    pm.response.to.have.status(400);",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{guest-access-token}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {},
+                "url": {
+                  "raw": "{{domain}}{{endpoint_products}}?category_id=99999",
+                  "host": [
+                    "{{domain}}{{endpoint_products}}"
+                  ],
+                  "query": [
+                    {
+                      "key": "category_id",
+                      "value": "99999",
+                      "equals": true
+                    }
+                  ]
+                },
+                "description": ""
+              },
+              "response": []
+            },
+            {
+              "name": "Page 1, Limit 4",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});",
+                      "",
+                      "pm.test(\"Retrieved 3 products from New Arrivals category\", function () {",
+                      "    var jsonData = pm.response.json();",
+                      "    var count = Object.keys(jsonData).length;",
+                      "    pm.expect(count).to.eql(4);",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{guest-access-token}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {},
+                "url": {
+                  "raw": "{{domain}}{{endpoint_products}}?page=1&limit=4",
+                  "host": [
+                    "{{domain}}{{endpoint_products}}"
+                  ],
+                  "query": [
+                    {
+                      "key": "page",
+                      "value": "1",
+                      "equals": true
+                    },
+                    {
+                      "key": "limit",
+                      "value": "4",
+                      "equals": true
+                    }
+                  ]
+                },
+                "description": ""
+              },
+              "response": []
+            }
+          ],
+          "_postman_isSubFolder": true
+        }
+      ]
+    },
+    {
+      "name": "/v2/products/:id",
+      "description": "",
+      "item": [
+        {
+          "name": "Guest",
+          "description": "",
+          "item": [
+            {
+              "name": "Bundled: 447",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});",
+                      "",
+                      "pm.test(\"Product is indeed bundled. Has stock data. Customer grp 0\", function () {",
+                      "    var jsonData = pm.response.json();",
+                      "    pm.expect(jsonData.type_id).to.eql('bundle');",
+                      "    pm.expect(jsonData.stock_item.product_id).to.eql('447');",
+                      "    pm.expect(jsonData.customer_group_id).to.eql(0);",
+                      "});",
+                      ""
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{guest-access-token}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {},
+                "url": {
+                  "raw": "{{domain}}{{endpoint_products}}/447",
+                  "host": [
+                    "{{domain}}{{endpoint_products}}"
+                  ],
+                  "path": [
+                    "447"
+                  ]
+                },
+                "description": "ID: 447\nType: Bundle\nName: Pillow and Throw Set\nSKU (dynamic): hdb010\nURL: pillow-and-throw-set\nCategory: Home & Decor -> Bed & Bath\nPrice: N/A\n\nBundle Items:\nTitle: Accent Pillow\nID: 24\nName: Titian Raw Silk Pillow | Shay Printed Pillow\nSKU: hdb005 | hdb006\nID: 381 | 382\nSelection ID: 91 | 92\nPrice: 125.00 | 210.00\n\nTitle: Decorative Throw\nID: 23\nName: Carnegie Alpaca Throw | Row Throw | Gramercy Throw\nSKU: hdb007 | hdb008 | hdb009\nID: 383 | 384 | 385\nPrice: 275.00 | 240.00 | 275.00\nSelection ID: 88 | 89 | 115"
+              },
+              "response": []
+            },
+            {
+              "name": "Configurable: Skirt",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});",
+                      "",
+                      "pm.test(\"Product is indeed configurable. Has stock data. Customer grp 0. Has children.\", function () {",
+                      "    var jsonData = pm.response.json();",
+                      "    pm.expect(jsonData.type_id).to.eql('configurable');",
+                      "    pm.expect(jsonData.stock_item.product_id).to.eql('422');",
+                      "    pm.expect(jsonData.customer_group_id).to.eql(0);",
+                      "    pm.expect(jsonData.children.attributes['92'].id).to.eql('92');",
+                      "});",
+                      ""
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{guest-access-token}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {},
+                "url": {
+                  "raw": "{{domain}}{{endpoint_products}}/422",
+                  "host": [
+                    "{{domain}}{{endpoint_products}}"
+                  ],
+                  "path": [
+                    "422"
+                  ]
+                },
+                "description": "ID: 422\nType: Configurable\nName: Essex Pencil Skirt\nSKU: wsd000c\nCategory: Dresses & Skirts\nPrice: $185.00\n\nSub-Products:\nID: 297 | 298 | 299 | 300 | 301\nName: Essex Pencil Skirt\nSKU: wsd000 | wsd001 | wsd002 | wsd003 | wsd004\nColor (ID: 92): Charcoal (ID: 17)\nSize (ID: 180): 2 (ID: 76) | 4 (ID: 75) | 6 (ID: 74) | 8 (ID: 73) | 10 (ID: 72)"
+              },
+              "response": []
+            },
+            {
+              "name": "Downloadable: 563",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});",
+                      "",
+                      "pm.test(\"Product is indeed donwloadable. Has stock data. Customer grp 0\", function () {",
+                      "    var jsonData = pm.response.json();",
+                      "    pm.expect(jsonData.type_id).to.eql('downloadable');",
+                      "    pm.expect(jsonData.stock_item.product_id).to.eql('563');",
+                      "    pm.expect(jsonData.customer_group_id).to.eql(0);",
+                      "});",
+                      ""
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{guest-access-token}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {},
+                "url": {
+                  "raw": "{{domain}}{{endpoint_products}}/563",
+                  "host": [
+                    "{{domain}}{{endpoint_products}}"
+                  ],
+                  "path": [
+                    "563"
+                  ]
+                },
+                "description": "ID: 563\nName: Fire [Kalima remix] by Unannounced Guest\nSKU: hbm010\nCategory: Music & Books\nURL: fire-kalima-remix-by-unannounced-guest\nPrice: 2.00\nQty: 1000"
+              },
+              "response": []
+            },
+            {
+              "name": "Grouped: 439",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});",
+                      "",
+                      "pm.test(\"Product is indeed grouped. Has stock data. Customer grp 0\", function () {",
+                      "    var jsonData = pm.response.json();",
+                      "    pm.expect(jsonData.type_id).to.eql('grouped');",
+                      "    pm.expect(jsonData.stock_item.product_id).to.eql('439');",
+                      "    pm.expect(jsonData.customer_group_id).to.eql(0);",
+                      "});",
+                      ""
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{guest-access-token}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {},
+                "url": {
+                  "raw": "{{domain}}{{endpoint_products}}/439",
+                  "host": [
+                    "{{domain}}{{endpoint_products}}"
+                  ],
+                  "path": [
+                    "439"
+                  ]
+                },
+                "description": "ID: 439\nName: Luggage Set\nType: Grouped\nSKU: abl008\nURL: luggage-set\nCategory: Bags & Luggage\n\nSub-Product:\nID: 541 | 377 | 376\nName: Classic Hardshell Suitcase 19\" | Classic Hardshell Suitcase 29\" | Classic Hardshell Suitcase 21\"\nSKU: abl009 | abl007 | abl006\nPrice: 600.00 | 750.00 | 650.00\nQty: 7 | 13 | 15"
+              },
+              "response": []
+            },
+            {
+              "name": "Nominal: 564",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});",
+                      "",
+                      "pm.test(\"Product is indeed nominal. Has stock data. Customer grp 0\", function () {",
+                      "    var jsonData = pm.response.json();",
+                      "    pm.expect(jsonData.type_id).to.eql('virtual');",
+                      "    pm.expect(jsonData.stock_item.product_id).to.eql('564');",
+                      "    pm.expect(jsonData.customer_group_id).to.eql(0);",
+                      "    pm.expect(jsonData.recurring_profile.start_date_is_editable).to.eql('1');",
+                      "});",
+                      ""
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{guest-access-token}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {},
+                "url": {
+                  "raw": "{{domain}}{{endpoint_products}}/564",
+                  "host": [
+                    "{{domain}}{{endpoint_products}}"
+                  ],
+                  "path": [
+                    "564"
+                  ]
+                },
+                "description": ""
+              },
+              "response": []
+            },
+            {
+              "name": "Simple: 554",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});",
+                      "",
+                      "pm.test(\"Product is indeed simple. Has stock data. Customer grp 0. No options.\", function () {",
+                      "    var jsonData = pm.response.json();",
+                      "    pm.expect(jsonData.type_id).to.eql('simple');",
+                      "    pm.expect(jsonData.stock_item.product_id).to.eql('554');",
+                      "    pm.expect(jsonData.customer_group_id).to.eql(0);",
+                      "    pm.expect(jsonData.has_options).to.eql('0');",
+                      "    pm.expect(jsonData.required_options).to.eql('0');",
+                      "});",
+                      ""
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{guest-access-token}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {},
+                "url": {
+                  "raw": "{{domain}}{{endpoint_products}}/554",
+                  "host": [
+                    "{{domain}}{{endpoint_products}}"
+                  ],
+                  "path": [
+                    "554"
+                  ]
+                },
+                "description": "ID: 554\nType: Simple\nName: Swiss Movement Sports Watch\nSKU: acj005\nURL: swiss-movement-sports-watch\nCategory: Jewelry\nPrice: $500.00\nQty: 3"
+              },
+              "response": []
+            },
+            {
+              "name": "Simple: 370 + Options",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});",
+                      "",
+                      "pm.test(\"Product is indeed simple. Has stock data. Customer grp 0.\", function () {",
+                      "    var jsonData = pm.response.json();",
+                      "    pm.expect(jsonData.type_id).to.eql('simple');",
+                      "    pm.expect(jsonData.stock_item.product_id).to.eql('370');",
+                      "    pm.expect(jsonData.customer_group_id).to.eql(0);",
+                      "});",
+                      "",
+                      "pm.test(\"Product indeed has custom options\", function () {",
+                      "    var jsonData = pm.response.json();",
+                      "    pm.expect(jsonData.has_custom_options).to.be.true;",
+                      "    pm.expect(jsonData.custom_options[0].product_id).to.eql('370');",
+                      "});",
+                      ""
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{guest-access-token}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {},
+                "url": {
+                  "raw": "{{domain}}{{endpoint_products}}/370",
+                  "host": [
+                    "{{domain}}{{endpoint_products}}"
+                  ],
+                  "path": [
+                    "370"
+                  ]
+                },
+                "description": ""
+              },
+              "response": []
+            },
+            {
+              "name": "GiftCard Physical/dropdown: 454",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "id": "8f139093-c317-437e-b371-544698256bd2",
+                    "type": "text/javascript",
+                    "exec": [
+                      "//Testing for EE edition specifics",
+                      "var jsonData = pm.response.json();",
+                      "if (pm.variables.get(\"mage_type\") === 'EE') {",
+                      "    pm.test(\"Status code is 200\", function () {",
+                      "        pm.response.to.have.status(200);",
+                      "    });",
+                      "",
+                      "    pm.test(\"Product is indeed GC. Has stock data. \", function () {",
+                      "        ",
+                      "        pm.expect(jsonData.type_id).to.eql('giftcard');",
+                      "        pm.expect(jsonData.stock_item.product_id).to.eql('454');",
+                      "    });",
+                      "} else {",
+                      "    pm.test(\"Product is not visible individually\", function () {",
+                      "        pm.response.to.have.status(404);",
+                      "    });",
+                      "}"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{guest-access-token}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {},
+                "url": {
+                  "raw": "{{domain}}{{endpoint_products}}/454",
+                  "host": [
+                    "{{domain}}{{endpoint_products}}"
+                  ],
+                  "path": [
+                    "454"
+                  ]
+                },
+                "description": ""
+              },
+              "response": []
+            }
+          ],
+          "_postman_isSubFolder": true
+        },
+        {
+          "name": "Customer",
+          "description": "",
+          "item": [
+            {
+              "name": "Bundled: 447",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});",
+                      "",
+                      "pm.test(\"Product is indeed bundled. Has stock data.\", function () {",
+                      "    var jsonData = pm.response.json();",
+                      "    pm.expect(jsonData.type_id).to.eql('bundle');",
+                      "    pm.expect(jsonData.stock_item.product_id).to.eql('447');",
+                      "});",
+                      ""
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{customer-access-token}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {},
+                "url": {
+                  "raw": "{{domain}}{{endpoint_products}}/447",
+                  "host": [
+                    "{{domain}}{{endpoint_products}}"
+                  ],
+                  "path": [
+                    "447"
+                  ]
+                },
+                "description": "ID: 447\nType: Bundle\nName: Pillow and Throw Set\nSKU (dynamic): hdb010\nURL: pillow-and-throw-set\nCategory: Home & Decor -> Bed & Bath\nPrice: N/A\n\nBundle Items:\nTitle: Accent Pillow\nID: 24\nName: Titian Raw Silk Pillow | Shay Printed Pillow\nSKU: hdb005 | hdb006\nID: 381 | 382\nSelection ID: 91 | 92\nPrice: 125.00 | 210.00\n\nTitle: Decorative Throw\nID: 23\nName: Carnegie Alpaca Throw | Row Throw | Gramercy Throw\nSKU: hdb007 | hdb008 | hdb009\nID: 383 | 384 | 385\nPrice: 275.00 | 240.00 | 275.00\nSelection ID: 88 | 89 | 115"
+              },
+              "response": []
+            },
+            {
+              "name": "Configurable: Skirt",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});",
+                      "",
+                      "pm.test(\"Product is indeed configurable. Has stock data. Has children.\", function () {",
+                      "    var jsonData = pm.response.json();",
+                      "    pm.expect(jsonData.type_id).to.eql('configurable');",
+                      "    pm.expect(jsonData.stock_item.product_id).to.eql('422');",
+                      "    pm.expect(jsonData.children.attributes['92'].id).to.eql('92');",
+                      "});",
+                      ""
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{customer-access-token}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {},
+                "url": {
+                  "raw": "{{domain}}{{endpoint_products}}/422",
+                  "host": [
+                    "{{domain}}{{endpoint_products}}"
+                  ],
+                  "path": [
+                    "422"
+                  ]
+                },
+                "description": "ID: 422\nType: Configurable\nName: Essex Pencil Skirt\nSKU: wsd000c\nCategory: Dresses & Skirts\nPrice: $185.00\n\nSub-Products:\nID: 297 | 298 | 299 | 300 | 301\nName: Essex Pencil Skirt\nSKU: wsd000 | wsd001 | wsd002 | wsd003 | wsd004\nColor (ID: 92): Charcoal (ID: 17)\nSize (ID: 180): 2 (ID: 76) | 4 (ID: 75) | 6 (ID: 74) | 8 (ID: 73) | 10 (ID: 72)"
+              },
+              "response": []
+            },
+            {
+              "name": "Downloadable: 563",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});",
+                      "",
+                      "pm.test(\"Product is indeed donwloadable. Has stock data.\", function () {",
+                      "    var jsonData = pm.response.json();",
+                      "    pm.expect(jsonData.type_id).to.eql('downloadable');",
+                      "    pm.expect(jsonData.stock_item.product_id).to.eql('563');",
+                      "});",
+                      ""
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{customer-access-token}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {},
+                "url": {
+                  "raw": "{{domain}}{{endpoint_products}}/563",
+                  "host": [
+                    "{{domain}}{{endpoint_products}}"
+                  ],
+                  "path": [
+                    "563"
+                  ]
+                },
+                "description": "ID: 563\nName: Fire [Kalima remix] by Unannounced Guest\nSKU: hbm010\nCategory: Music & Books\nURL: fire-kalima-remix-by-unannounced-guest\nPrice: 2.00\nQty: 1000"
+              },
+              "response": []
+            },
+            {
+              "name": "Grouped: 439",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});",
+                      "",
+                      "pm.test(\"Product is indeed grouped. Has stock data. Customer grp 0\", function () {",
+                      "    var jsonData = pm.response.json();",
+                      "    pm.expect(jsonData.type_id).to.eql('grouped');",
+                      "    pm.expect(jsonData.stock_item.product_id).to.eql('439');",
+                      "});",
+                      ""
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{customer-access-token}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {},
+                "url": {
+                  "raw": "{{domain}}{{endpoint_products}}/439",
+                  "host": [
+                    "{{domain}}{{endpoint_products}}"
+                  ],
+                  "path": [
+                    "439"
+                  ]
+                },
+                "description": "ID: 439\nName: Luggage Set\nType: Grouped\nSKU: abl008\nURL: luggage-set\nCategory: Bags & Luggage\n\nSub-Product:\nID: 541 | 377 | 376\nName: Classic Hardshell Suitcase 19\" | Classic Hardshell Suitcase 29\" | Classic Hardshell Suitcase 21\"\nSKU: abl009 | abl007 | abl006\nPrice: 600.00 | 750.00 | 650.00\nQty: 7 | 13 | 15"
+              },
+              "response": []
+            },
+            {
+              "name": "Nominal: 564",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});",
+                      "",
+                      "pm.test(\"Product is indeed nominal. Has stock data.\", function () {",
+                      "    var jsonData = pm.response.json();",
+                      "    pm.expect(jsonData.type_id).to.eql('virtual');",
+                      "    pm.expect(jsonData.stock_item.product_id).to.eql('564');",
+                      "    pm.expect(jsonData.recurring_profile.start_date_is_editable).to.eql('1');",
+                      "});",
+                      ""
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{customer-access-token}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {},
+                "url": {
+                  "raw": "{{domain}}{{endpoint_products}}/564",
+                  "host": [
+                    "{{domain}}{{endpoint_products}}"
+                  ],
+                  "path": [
+                    "564"
+                  ]
+                },
+                "description": ""
+              },
+              "response": []
+            },
+            {
+              "name": "Simple: 554",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});",
+                      "",
+                      "pm.test(\"Product is indeed simple. Has stock data. No options.\", function () {",
+                      "    var jsonData = pm.response.json();",
+                      "    pm.expect(jsonData.type_id).to.eql('simple');",
+                      "    pm.expect(jsonData.stock_item.product_id).to.eql('554');",
+                      "    pm.expect(jsonData.has_options).to.eql('0');",
+                      "    pm.expect(jsonData.required_options).to.eql('0');",
+                      "});",
+                      ""
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{customer-access-token}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {},
+                "url": {
+                  "raw": "{{domain}}{{endpoint_products}}/554",
+                  "host": [
+                    "{{domain}}{{endpoint_products}}"
+                  ],
+                  "path": [
+                    "554"
+                  ]
+                },
+                "description": "ID: 554\nType: Simple\nName: Swiss Movement Sports Watch\nSKU: acj005\nURL: swiss-movement-sports-watch\nCategory: Jewelry\nPrice: $500.00\nQty: 3"
+              },
+              "response": []
+            },
+            {
+              "name": "Simple: 370 + Options",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"Status code is 200\", function () {",
+                      "    pm.response.to.have.status(200);",
+                      "});",
+                      "",
+                      "pm.test(\"Product is indeed simple. Has stock data.\", function () {",
+                      "    var jsonData = pm.response.json();",
+                      "    pm.expect(jsonData.type_id).to.eql('simple');",
+                      "    pm.expect(jsonData.stock_item.product_id).to.eql('370');",
+                      "});",
+                      "",
+                      "pm.test(\"Product indeed has custom options\", function () {",
+                      "    var jsonData = pm.response.json();",
+                      "    pm.expect(jsonData.has_custom_options).to.be.true;",
+                      "    pm.expect(jsonData.custom_options[0].product_id).to.eql('370');",
+                      "});",
+                      ""
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{customer-access-token}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {},
+                "url": {
+                  "raw": "{{domain}}{{endpoint_products}}/370",
+                  "host": [
+                    "{{domain}}{{endpoint_products}}"
+                  ],
+                  "path": [
+                    "370"
+                  ]
+                },
+                "description": ""
+              },
+              "response": []
+            },
+            {
+              "name": "GiftCard Physical/dropdown: 454",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "id": "fff5006d-d64d-4a12-bd06-e20c18783d7c",
+                    "type": "text/javascript",
+                    "exec": [
+                      "//Testing for EE edition specifics",
+                      "var jsonData = pm.response.json();",
+                      "if (pm.variables.get(\"mage_type\") === 'EE') {",
+                      "    pm.test(\"Status code is 200\", function () {",
+                      "        pm.response.to.have.status(200);",
+                      "    });",
+                      "",
+                      "    pm.test(\"Product is indeed GC. Has stock data. \", function () {",
+                      "        ",
+                      "        pm.expect(jsonData.type_id).to.eql('giftcard');",
+                      "        pm.expect(jsonData.stock_item.product_id).to.eql('454');",
+                      "    });",
+                      "} else {",
+                      "    pm.test(\"Product is not visible individually\", function () {",
+                      "        pm.response.to.have.status(404);",
+                      "    });",
+                      "}"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{customer-access-token}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {},
+                "url": {
+                  "raw": "{{domain}}{{endpoint_products}}/454",
+                  "host": [
+                    "{{domain}}{{endpoint_products}}"
+                  ],
+                  "path": [
+                    "454"
+                  ]
+                },
+                "description": ""
+              },
+              "response": []
+            }
+          ],
+          "_postman_isSubFolder": true
+        }
+      ]
+    },
+    {
+      "name": "Cart Rules (no coupon)",
+      "description": "Tests cart rule combinations that do not have a coupon code attached to them",
+      "item": [
+        {
+          "name": "Customer",
+          "description": "",
+          "item": [
+            {
+              "name": "Buy X get Y free",
+              "description": "This cart rule ID is 38. Needs to have 2+ items from category Shoes to make one free. 1 use per customer. Customer group: General, VIP, Private Sales Member(EE)",
+              "item": [
+                {
+                  "name": "Create customer cart",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "var jsonData = pm.response.json();",
+                          "if (responseCode.code === 200 && jsonData.hasOwnProperty('cartId')) {",
+                          "    pm.environment.set(\"cartId\", jsonData.cartId);",
+                          "    tests[\"Cart ID is returned\"] = isNumeric(jsonData.cartId) === true;",
+                          "} else {",
+                          "    tests[\"Cart ID is not returned\"] = false;",
+                          "}",
+                          "",
+                          "pm.test('Successfull call', function(){",
+                          "    pm.response.to.be.success;",
+                          "});",
+                          "",
+                          "function isNumeric(n) {",
+                          "  return !isNaN(parseFloat(n)) && isFinite(n);",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "bearer",
+                      "bearer": [
+                        {
+                          "key": "token",
+                          "value": "{{customer-access-token}}",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{}"
+                    },
+                    "url": {
+                      "raw": "{{domain}}{{endpoint_carts}}",
+                      "host": [
+                        "{{domain}}{{endpoint_carts}}"
+                      ]
+                    },
+                    "description": "Creates a customer cart"
+                  },
+                  "response": []
+                },
+                {
+                  "name": "Add Configurable: Boots",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Successfull call', function(){",
+                          "    pm.response.to.be.success;",
+                          "});"
+                        ]
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "bearer",
+                      "bearer": [
+                        {
+                          "key": "token",
+                          "value": "{{customer-access-token}}",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "[\n  {\n    \t\"product\": {\n\t\t    \"product_id\": \"431\",\n\t\t    \"qty\": 2,\n\t\t    \"super_attribute\": {\n\t\t\t      \"92\": \"20\",\n\t\t\t      \"186\": \"102\"\n\t\t\t}\n\t\t}\n  }\n]"
+                    },
+                    "url": {
+                      "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                      "host": [
+                        "{{domain}}{{endpoint_carts_id_items}}"
+                      ]
+                    },
+                    "description": "ID: 431\nType: Configurable\nName: Ann Ankle Boot\nSKU: aws005c\nURL: borgha-ankle-boot\nPrice: $470.00\nCategory: Shoes\n\n\nSub-Products:\nID: 345 | 346 | 347 | 348 | 349\nName: Ann Ankle Boot\nSKU: aws005 | aws006 | aws007 | aws008 | aws009\nColor (ID: 92): Black (ID: 20)\nShoe size (ID: 186): 6 (ID: 102) | 7 (ID: 101) | 8 (ID: 100) | 9 (ID: 99) | 10 (ID: 98)"
+                  },
+                  "response": []
+                },
+                {
+                  "name": "Buy one get one free",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test(\"Successfully loaded cart via ME endpoint\", function () {",
+                          "    pm.response.to.have.status(200);",
+                          "});",
+                          "",
+                          "pm.test(\"Boots in cart with one added free\", function () {",
+                          "    var jsonData = pm.response.json();",
+                          "    pm.expect(jsonData.items_qty).to.eql(\"2.0000\");",
+                          "    pm.expect(jsonData.grand_total).to.eql(\"470.0000\");",
+                          "});"
+                        ]
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "bearer",
+                      "bearer": [
+                        {
+                          "key": "token",
+                          "value": "{{customer-access-token}}",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{}"
+                    },
+                    "url": {
+                      "raw": "{{domain}}{{endpoint_carts}}/me",
+                      "host": [
+                        "{{domain}}{{endpoint_carts}}"
+                      ],
+                      "path": [
+                        "me"
+                      ]
+                    },
+                    "description": ""
+                  },
+                  "response": []
+                }
+              ],
+              "_postman_isSubFolder": true
+            }
+          ],
+          "_postman_isSubFolder": true
+        },
+        {
+          "name": "Guest",
+          "description": "",
+          "item": [
+            {
+              "name": "Qty > 5",
+              "description": "",
+              "item": [
+                {
+                  "name": "/carts: Guest Cart",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "var jsonData = pm.response.json();",
+                          "if (responseCode.code === 200 && jsonData.hasOwnProperty('cartId')) {",
+                          "    pm.environment.set(\"cartId\", jsonData.cartId);",
+                          "    tests[\"Cart ID is returned\"] = isNumeric(jsonData.cartId) === true;",
+                          "} else {",
+                          "    tests[\"Cart ID is not returned\"] = false;",
+                          "}",
+                          "",
+                          "pm.test('Successfull call', function(){",
+                          "    pm.response.to.be.success;",
+                          "});",
+                          "",
+                          "function isNumeric(n) {",
+                          "  return !isNaN(parseFloat(n)) && isFinite(n);",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "bearer",
+                      "bearer": [
+                        {
+                          "key": "token",
+                          "value": "{{guest-access-token}}",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{}"
+                    },
+                    "url": {
+                      "raw": "{{domain}}{{endpoint_carts}}",
+                      "host": [
+                        "{{domain}}{{endpoint_carts}}"
+                      ]
+                    },
+                    "description": "Creates a guest cart and assigns the local cartId variable from the one returned"
+                  },
+                  "response": []
+                },
+                {
+                  "name": "Add grouped: qty6",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test('Successfull call', function(){",
+                          "    pm.response.to.be.success;",
+                          "});"
+                        ]
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "bearer",
+                      "bearer": [
+                        {
+                          "key": "token",
+                          "value": "{{guest-access-token}}",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "[\n  {\n    \"product\": {\n\t    \"product_id\": \"439\",\n\t    \"qty\": 1,\n\t    \"super_group\": {\n\t      \"541\" : 6\n\t    }\n\t  }\n  }\n]"
+                    },
+                    "url": {
+                      "raw": "{{domain}}{{endpoint_carts_id_items}}",
+                      "host": [
+                        "{{domain}}{{endpoint_carts_id_items}}"
+                      ]
+                    },
+                    "description": "ID: 439\nName: Luggage Set\nType: Grouped\nSKU: abl008\nURL: luggage-set\nCategory: Bags & Luggage\n\nSub-Product:\nID: 541 | 377 | 376\nName: Classic Hardshell Suitcase 19\" | Classic Hardshell Suitcase 29\" | Classic Hardshell Suitcase 21\"\nSKU: abl009 | abl007 | abl006\nPrice: 600.00 | 750.00 | 650.00\nQty: 7 | 13 | 15"
+                  },
+                  "response": []
+                },
+                {
+                  "name": "Cart has discount",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "pm.test(\"Status code is 200\", function () {",
+                          "    pm.response.to.have.status(200);",
+                          "});",
+                          "",
+                          "//Tests customer segments, but they are a tricky beast as they get picked up",
+                          "//from customer frontend session + log. This needs to be revistied.",
+                          "if (pm.environment.get(\"mage_type\") === 'EE' && false) {",
+                          "    pm.test(\"We have a 15 off discount\", function () {",
+                          "        var jsonData = pm.response.json();",
+                          "        pm.expect(jsonData.totals.discount.value).to.eql(\"-15.0000\");",
+                          "    });",
+                          "}",
+                          "",
+                          ""
+                        ]
+                      }
+                    }
+                  ],
+                  "request": {
+                    "auth": {
+                      "type": "bearer",
+                      "bearer": [
+                        {
+                          "key": "token",
+                          "value": "{{guest-access-token}}",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{}"
+                    },
+                    "url": {
+                      "raw": "{{domain}}{{endpoint_carts}}/{{cartId}}",
+                      "host": [
+                        "{{domain}}{{endpoint_carts}}"
+                      ],
+                      "path": [
+                        "{{cartId}}"
+                      ]
+                    },
+                    "description": ""
+                  },
+                  "response": []
+                }
+              ],
+              "_postman_isSubFolder": true
+            }
+          ],
+          "_postman_isSubFolder": true
+        }
+      ]
+    },
+    {
+      "name": "auth/token: CORS",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test(\"Successful CORS call per definition\", function () {",
+              "    pm.response.to.have.status(200);",
+              "});",
+              "tests[\"Body is empty\"] = responseBody === \"\";",
+              "tests[\"Allow-Headers is proper\"] = postman.getResponseHeader(\"Access-Control-Allow-Headers\") === 'Content-Type,Version,Authorization,PHP_AUTH_USER,PHP_AUTH_PW';",
+              "tests[\"Allow-Methods are proper\"] = postman.getResponseHeader(\"Access-Control-Allow-Methods\") === 'GET, POST, UPDATE, DELETE, OPTIONS';",
+              "tests[\"Allow-Origin is *\"] = postman.getResponseHeader(\"Access-Control-Allow-Origin\") === '*';"
+            ]
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          },
+          {
+            "key": "Access-Control-Request-Method",
+            "value": "POST"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{}"
+        },
+        "url": {
+          "raw": "{{domain}}{{endpoint_auth_token}}",
+          "host": [
+            "{{domain}}{{endpoint_auth_token}}"
+          ]
+        },
+        "description": ""
+      },
+      "response": []
+    }
+  ]
+}

--- a/tests/postman/newman/globals.json
+++ b/tests/postman/newman/globals.json
@@ -1,0 +1,57 @@
+{
+  "id": "797f0e1a-0e7b-d435-d59c-584db59a0944",
+  "name": "Postman Globals",
+  "values": [
+    {
+      "key": "endpoint_auth_token",
+      "value": "shopgate/v2/auth/token",
+      "enabled": true,
+      "type": "text"
+    },
+    {
+      "key": "endpoint_carts",
+      "value": "shopgate/v2/carts",
+      "enabled": true,
+      "type": "text"
+    },
+    {
+      "key": "endpoint_carts_id_items",
+      "value": "{{endpoint_carts}}/{{cartId}}/items",
+      "enabled": true,
+      "type": "text"
+    },
+    {
+      "key": "endpoint_carts_me_items",
+      "value": "{{endpoint_carts}}/me/items",
+      "enabled": true,
+      "type": "text"
+    },
+    {
+      "key": "endpoint_carts_id_checkoutUrl",
+      "value": "{{endpoint_carts}}/{{cartId}}/checkoutUrl",
+      "enabled": true,
+      "type": "text"
+    },
+    {
+      "key": "endpoint_carts_id_customer",
+      "value": "{{endpoint_carts}}/{{cartId}}/customer",
+      "enabled": true,
+      "type": "text"
+    },
+    {
+      "key": "endpoint_products",
+      "value": "shopgate/v2/products",
+      "enabled": true,
+      "type": "text"
+    },
+    {
+      "key": "mage_type",
+      "value": "EE",
+      "enabled": true,
+      "type": "text"
+    }
+  ],
+  "_postman_variable_scope": "globals",
+  "_postman_exported_at": "2017-11-27T07:36:16.292Z",
+  "_postman_exported_using": "Postman/5.3.2"
+}

--- a/tests/postman/test_env_setup.sh
+++ b/tests/postman/test_env_setup.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Install Apache & Enable php-fpm
+sudo apt-get update
+sudo apt-get install apache2 libapache2-mod-fastcgi
+sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
+sudo a2enmod rewrite actions fastcgi alias
+echo "cgi.fix_pathinfo = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+echo "always_populate_raw_post_data=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+sudo sed -i -e "s,www-data,travis,g" /etc/apache2/envvars
+sudo chown -R travis:travis /var/lib/apache2/fastcgi
+~/.phpenv/versions/$(phpenv version-name)/sbin/php-fpm
+
+# configure apache virtual hosts
+sudo cp -f ./tests/postman/travis-ci-apache /etc/apache2/sites-available/default
+sudo chown -R travis:travis ${WEB_PATH}
+sudo chmod 750 ${WEB_PATH}
+sudo chown -R travis:travis /var/lock/apache2/
+sudo service apache2 restart
+
+# n98 related
+wget --quiet https://files.magerun.net/n98-magerun.phar
+chmod +x ./n98-magerun.phar
+sudo mv ./n98-magerun.phar /usr/local/bin/n98
+sudo mkdir -p /usr/local/share/n98-magerun/scripts
+sudo cp -a ./tests/postman/n98-scripts/* /usr/local/share/n98-magerun/scripts/
+sudo chown -R travis:travis /usr/local/share/n98-magerun
+sudo chmod +x /usr/local/share/n98-magerun/scripts/*.magerun
+sudo cp -a ./tests/postman/.n98-magerun.yaml ~/
+sudo chmod +x ~/.n98-magerun.yaml
+
+if [[ ${MAGE_LOCALE} == "en_US" ]];
+then
+	sudo sed -e "s?EUR?USD?g" --in-place ~/.n98-magerun.yaml
+	sudo sed -e "s?de_DE?${MAGE_LOCALE}?g" --in-place ~/.n98-magerun.yaml
+	echo 'subbed default config values'
+fi
+
+if [[ ${MAGE_TYPE} == "EE" ]]; then
+	pip install --user awscli
+fi
+
+# newman related
+npm install newman --global

--- a/tests/postman/travis-ci-apache
+++ b/tests/postman/travis-ci-apache
@@ -1,0 +1,23 @@
+<VirtualHost *:80>
+	DocumentRoot /var/www
+	<Directory />
+		Options FollowSymLinks
+		AllowOverride None
+	</Directory>
+	<Directory /var/www/>
+		Options FollowSymLinks MultiViews ExecCGI
+		AllowOverride All
+		Order allow,deny
+		Allow from all
+	</Directory>
+	<IfModule mod_fastcgi.c>
+		AddHandler php5-fcgi .php
+		Action php5-fcgi /php5-fcgi
+		Alias /php5-fcgi /usr/lib/cgi-bin/php5-fcgi
+		FastCgiExternalServer /usr/lib/cgi-bin/php5-fcgi -host 127.0.0.1:9000 -pass-header Authorization -pass-header Content-Type
+		
+		<Directory /usr/lib/cgi-bin>
+			Allow from all
+		</Directory>
+	</IfModule>
+</VirtualHost>


### PR DESCRIPTION
Travis tests that cover PHP 5.3, 5.4, 5.5, 5.6
Mage versions:
CE 1.7.0.2, 1.8.0.0 (en_US), 1.9.3.6
EE 1.12.0.2. 1.13.0.2, 1.14.3.7

Fixes for a locale bug when translating product date input from US to DE and vise-versa
Fixes a dependency on /shopgate frontend controller route, forgot to add it when removing dependency on Framework
Fixes an issues with GET product retrieving invisible products to Guest customers (since they are technically Admin)
Fixes travis deployment not composer pulling library dependencies (e.g. oAuth2 plugin)

Note: EE tests will be skipped when PR's are made from a fork because secure credentials are not [used](https://docs.travis-ci.com/user/pull-requests/#Pull-Requests-and-Security-Restrictions) for those.