### PR TITLE
WEBC-689 Fix for using mage 1.9 functions with enabled product price taxes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,6 +68,7 @@ env:
     CFG_API_SHOP_NUMBER="12345"
     CFG_API_KEY="11111111111111111111"
     CFG_MINIMUM_ORDER_ACTIVE="1"
+    CFG_PRICE_INC_TAX="1"
     USER1_EMAIL="konstantin.kiritsenko+1@shopgate.com"
     USER_PASS="test123"
   matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Validation for Minimum order amount
 ### Fixed
 - Checkout url when using store code in magento url
+- Issues with products endpoint showing tax prices for Magento below CE 1.9 & EE 1.14
 
 ## [3.1.1] - 2018-03-28
 ### Added

--- a/src/app/code/community/Shopgate/Cloudapi/Model/Api2/Products/Rest.php
+++ b/src/app/code/community/Shopgate/Cloudapi/Model/Api2/Products/Rest.php
@@ -296,7 +296,8 @@ abstract class Shopgate_Cloudapi_Model_Api2_Products_Rest extends Shopgate_Cloud
         if ($taxClassId && $priceIncludesTax) {
             $taxHelper = Mage::helper('tax');
             if (method_exists($taxHelper, 'isCrossBorderTradeEnabled')
-                && $taxHelper->isCrossBorderTradeEnabled($store)) {
+                && $taxHelper->isCrossBorderTradeEnabled($store)
+            ) {
                 $includingPercent = $percent;
             } else {
                 $request = method_exists($taxCalculator, 'getDefaultRateRequest')

--- a/tests/postman/magento_setup.sh
+++ b/tests/postman/magento_setup.sh
@@ -28,6 +28,7 @@ n98 script:repo:run n98-setup \
 -d shop_number=${CFG_API_SHOP_NUMBER} \
 -d customer_number=${CFG_API_CUSTOMER_NUMBER} \
 -d minimum_order_active=${CFG_MINIMUM_ORDER_ACTIVE} \
+-d price_includes_tax=${CFG_PRICE_INC_TAX} \
 -d user1_email=${USER1_EMAIL} \
 -d user_pass=${USER_PASS} \
 -d misc_param1=${DOWNLOAD} \

--- a/tests/postman/n98-scripts/n98-setup.magerun
+++ b/tests/postman/n98-scripts/n98-setup.magerun
@@ -8,6 +8,7 @@ config:set --scope="websites" --scope-id="1" "shopgate_cloudapi/authentication/s
 config:set --scope="websites" --scope-id="1" "shopgate_cloudapi/authentication/api_key" ${api_key}
 config:set --scope="default" --scope-id="0" "sales/minimum_order/amount" "21"
 config:set --scope="default" --scope-id="0" "sales/minimum_order/active" ${minimum_order_active}
+config:set --scope="default" --scope-id="0" "tax/calculation/price_includes_tax" ${price_includes_tax}
 
 # creates in General group by default, no good way to set up without using php scripts
 customer:create ${user1_email} ${user_pass} "Test1" "Mock1" "1"

--- a/tests/postman/newman/collection.json
+++ b/tests/postman/newman/collection.json
@@ -1,8 +1,7 @@
 {
   "info": {
+    "_postman_id": "ebfa6c75-7385-47e4-89e2-e7769174325f",
     "name": "Mage Cloud",
-    "_postman_id": "0e04f1bb-d98d-47e3-bbed-f31659fae559",
-    "description": "",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "item": [
@@ -65,8 +64,7 @@
               "host": [
                 "{{domain}}{{endpoint_auth_token}}"
               ]
-            },
-            "description": null
+            }
           },
           "response": []
         },
@@ -125,8 +123,7 @@
               "host": [
                 "{{domain}}{{endpoint_auth_token}}"
               ]
-            },
-            "description": null
+            }
           },
           "response": []
         },
@@ -197,8 +194,7 @@
               "host": [
                 "{{domain}}{{endpoint_auth_token}}"
               ]
-            },
-            "description": null
+            }
           },
           "response": []
         },
@@ -255,8 +251,7 @@
               "host": [
                 "{{domain}}{{endpoint_auth_token}}"
               ]
-            },
-            "description": null
+            }
           },
           "response": []
         },
@@ -315,8 +310,7 @@
               "host": [
                 "{{domain}}{{endpoint_auth_token}}"
               ]
-            },
-            "description": null
+            }
           },
           "response": []
         }
@@ -484,8 +478,7 @@
                   "path": [
                     "{{cartId}}"
                   ]
-                },
-                "description": null
+                }
               },
               "response": []
             },
@@ -534,8 +527,7 @@
                   "path": [
                     "000"
                   ]
-                },
-                "description": null
+                }
               },
               "response": []
             }
@@ -746,8 +738,7 @@
                   "path": [
                     "{{cartId}}"
                   ]
-                },
-                "description": null
+                }
               },
               "response": []
             }
@@ -869,8 +860,7 @@
                       "host": [
                         "{{domain}}{{endpoint_carts_id_items}}"
                       ]
-                    },
-                    "description": null
+                    }
                   },
                   "response": []
                 },
@@ -1643,8 +1633,7 @@
                       "host": [
                         "{{domain}}{{endpoint_carts_id_items}}"
                       ]
-                    },
-                    "description": null
+                    }
                   },
                   "response": []
                 },
@@ -1815,8 +1804,7 @@
                           "host": [
                             "{{domain}}{{endpoint_carts_id_items}}"
                           ]
-                        },
-                        "description": null
+                        }
                       },
                       "response": []
                     },
@@ -2059,7 +2047,7 @@
                 },
                 {
                   "name": "Minimum order amount",
-                  "description": "",
+                  "description": null,
                   "item": [
                     {
                       "name": "/carts: customer",
@@ -2173,7 +2161,7 @@
                         {
                           "listen": "test",
                           "script": {
-                            "id": "24615cae-6758-4354-a9d2-cde88d2ac5a1",
+                            "id": "8e283f85-23bb-447b-b1ba-904f6e460266",
                             "type": "text/javascript",
                             "exec": [
                               "var jsonData = pm.response.json();",
@@ -2187,13 +2175,13 @@
                               "});",
                               "",
                               "pm.test(\"Cart has errors\", function () {",
-															"    if (pm.variables.get(\"minimum_order_active\") === '1') {",
-                              "    pm.expect(jsonData.has_error).to.eql(true);",
-                              "    pm.expect(jsonData.errors).to.not.be.empty;",
-															"    } else {",
-															"        pm.expect(jsonData.has_error).to.not.exist;",
-															"        pm.expect(jsonData.errors).to.not.exist;",
-															"    }",
+                              "    if (pm.variables.get(\"minimum_order_active\") === '1') {",
+                              "        pm.expect(jsonData.has_error).to.eql(true);",
+                              "        pm.expect(jsonData.errors).to.not.be.empty;",
+                              "    } else {",
+                              "        pm.expect(jsonData.has_error).to.not.exist;",
+                              "        pm.expect(jsonData.errors).to.not.exist;",
+                              "    }",
                               "});"
                             ]
                           }
@@ -2505,8 +2493,7 @@
                       "host": [
                         "{{domain}}{{endpoint_carts_id_items}}"
                       ]
-                    },
-                    "description": null
+                    }
                   },
                   "response": []
                 },
@@ -3127,8 +3114,7 @@
                           "host": [
                             "{{domain}}{{endpoint_carts_id_items}}"
                           ]
-                        },
-                        "description": null
+                        }
                       },
                       "response": []
                     },
@@ -3183,8 +3169,7 @@
                           "path": [
                             "{{cartId}}"
                           ]
-                        },
-                        "description": null
+                        }
                       },
                       "response": []
                     }
@@ -3455,8 +3440,7 @@
                       "path": [
                         "{{cartId}}"
                       ]
-                    },
-                    "description": null
+                    }
                   },
                   "response": []
                 },
@@ -3666,8 +3650,7 @@
                           "host": [
                             "{{domain}}{{endpoint_carts_id_items}}"
                           ]
-                        },
-                        "description": null
+                        }
                       },
                       "response": []
                     },
@@ -3894,8 +3877,7 @@
                           "path": [
                             "{{cartId}}"
                           ]
-                        },
-                        "description": null
+                        }
                       },
                       "response": []
                     },
@@ -3944,8 +3926,7 @@
                           "query": [
                             {
                               "key": "cartItemIds",
-                              "value": "{{cart_items_to_remove}}",
-                              "equals": true
+                              "value": "{{cart_items_to_remove}}"
                             }
                           ]
                         },
@@ -4003,8 +3984,7 @@
                           "path": [
                             "{{cartId}}"
                           ]
-                        },
-                        "description": null
+                        }
                       },
                       "response": []
                     }
@@ -4236,8 +4216,7 @@
                               "path": [
                                 "{{cartId}}"
                               ]
-                            },
-                            "description": null
+                            }
                           },
                           "response": []
                         }
@@ -4407,8 +4386,7 @@
                           "path": [
                             "{{cartId}}"
                           ]
-                        },
-                        "description": null
+                        }
                       },
                       "response": []
                     },
@@ -4509,8 +4487,7 @@
                           "path": [
                             "{{cartId}}"
                           ]
-                        },
-                        "description": null
+                        }
                       },
                       "response": []
                     }
@@ -4677,8 +4654,7 @@
                           "path": [
                             "{{cartId}}"
                           ]
-                        },
-                        "description": null
+                        }
                       },
                       "response": []
                     },
@@ -4779,8 +4755,7 @@
                           "path": [
                             "{{cartId}}"
                           ]
-                        },
-                        "description": null
+                        }
                       },
                       "response": []
                     },
@@ -4928,8 +4903,7 @@
                           "path": [
                             "{{cartId}}"
                           ]
-                        },
-                        "description": null
+                        }
                       },
                       "response": []
                     },
@@ -5030,8 +5004,7 @@
                           "path": [
                             "{{cartId}}"
                           ]
-                        },
-                        "description": null
+                        }
                       },
                       "response": []
                     },
@@ -5296,8 +5269,7 @@
                               "path": [
                                 "{{cartId}}"
                               ]
-                            },
-                            "description": null
+                            }
                           },
                           "response": []
                         },
@@ -5398,8 +5370,7 @@
                               "path": [
                                 "{{cartId}}"
                               ]
-                            },
-                            "description": null
+                            }
                           },
                           "response": []
                         },
@@ -5500,8 +5471,7 @@
                               "path": [
                                 "{{cartId}}"
                               ]
-                            },
-                            "description": null
+                            }
                           },
                           "response": []
                         }
@@ -5668,8 +5638,7 @@
                               "path": [
                                 "{{cartId}}"
                               ]
-                            },
-                            "description": null
+                            }
                           },
                           "response": []
                         },
@@ -5770,8 +5739,7 @@
                               "path": [
                                 "{{cartId}}"
                               ]
-                            },
-                            "description": null
+                            }
                           },
                           "response": []
                         },
@@ -5820,12 +5788,10 @@
                               "query": [
                                 {
                                   "key": "cartItemIds",
-                                  "value": "COUPON_XXX",
-                                  "equals": true
+                                  "value": "COUPON_XXX"
                                 }
                               ]
-                            },
-                            "description": null
+                            }
                           },
                           "response": []
                         },
@@ -5885,8 +5851,7 @@
                               "path": [
                                 "{{cartId}}"
                               ]
-                            },
-                            "description": null
+                            }
                           },
                           "response": []
                         }
@@ -6114,8 +6079,7 @@
                               "path": [
                                 "{{cartId}}"
                               ]
-                            },
-                            "description": null
+                            }
                           },
                           "response": []
                         }
@@ -6325,8 +6289,7 @@
                           "path": [
                             "{{cartId}}"
                           ]
-                        },
-                        "description": null
+                        }
                       },
                       "response": []
                     }
@@ -6540,8 +6503,7 @@
                           "path": [
                             "{{cartId}}"
                           ]
-                        },
-                        "description": null
+                        }
                       },
                       "response": []
                     },
@@ -6642,8 +6604,7 @@
                           "path": [
                             "{{cartId}}"
                           ]
-                        },
-                        "description": null
+                        }
                       },
                       "response": []
                     }
@@ -6861,8 +6822,7 @@
                               "path": [
                                 "{{cartId}}"
                               ]
-                            },
-                            "description": null
+                            }
                           },
                           "response": []
                         },
@@ -6963,8 +6923,7 @@
                               "path": [
                                 "{{cartId}}"
                               ]
-                            },
-                            "description": null
+                            }
                           },
                           "response": []
                         },
@@ -7237,8 +7196,7 @@
                               "path": [
                                 "{{cartId}}"
                               ]
-                            },
-                            "description": null
+                            }
                           },
                           "response": []
                         },
@@ -7287,12 +7245,10 @@
                               "query": [
                                 {
                                   "key": "cartItemIds",
-                                  "value": "COUPON_XXX",
-                                  "equals": true
+                                  "value": "COUPON_XXX"
                                 }
                               ]
-                            },
-                            "description": null
+                            }
                           },
                           "response": []
                         },
@@ -7352,8 +7308,7 @@
                               "path": [
                                 "{{cartId}}"
                               ]
-                            },
-                            "description": null
+                            }
                           },
                           "response": []
                         }
@@ -7545,8 +7500,7 @@
                               "path": [
                                 "{{cartId}}"
                               ]
-                            },
-                            "description": null
+                            }
                           },
                           "response": []
                         }
@@ -7833,8 +7787,7 @@
                               "path": [
                                 "{{cartId}}"
                               ]
-                            },
-                            "description": null
+                            }
                           },
                           "response": []
                         },
@@ -7935,8 +7888,7 @@
                               "path": [
                                 "{{cartId}}"
                               ]
-                            },
-                            "description": null
+                            }
                           },
                           "response": []
                         },
@@ -7982,8 +7934,7 @@
                               "host": [
                                 "{{domain}}{{endpoint_carts_id_items}}"
                               ]
-                            },
-                            "description": null
+                            }
                           },
                           "response": []
                         },
@@ -8043,8 +7994,7 @@
                               "path": [
                                 "{{cartId}}"
                               ]
-                            },
-                            "description": null
+                            }
                           },
                           "response": []
                         }
@@ -8211,8 +8161,7 @@
                               "path": [
                                 "{{cartId}}"
                               ]
-                            },
-                            "description": null
+                            }
                           },
                           "response": []
                         },
@@ -8313,8 +8262,7 @@
                               "path": [
                                 "{{cartId}}"
                               ]
-                            },
-                            "description": null
+                            }
                           },
                           "response": []
                         },
@@ -8379,8 +8327,7 @@
                               "path": [
                                 "{{cartId}}"
                               ]
-                            },
-                            "description": null
+                            }
                           },
                           "response": []
                         },
@@ -8476,8 +8423,7 @@
                               "query": [
                                 {
                                   "key": "cartItemIds",
-                                  "value": "{{cart_items_to_remove}}COUPON_XXX",
-                                  "equals": true
+                                  "value": "{{cart_items_to_remove}}COUPON_XXX"
                                 }
                               ]
                             },
@@ -8727,8 +8673,7 @@
                               "path": [
                                 "{{cartId}}"
                               ]
-                            },
-                            "description": null
+                            }
                           },
                           "response": []
                         }
@@ -9016,8 +8961,7 @@
                               "path": [
                                 "{{cartId}}"
                               ]
-                            },
-                            "description": null
+                            }
                           },
                           "response": []
                         },
@@ -9118,8 +9062,7 @@
                               "path": [
                                 "{{cartId}}"
                               ]
-                            },
-                            "description": null
+                            }
                           },
                           "response": []
                         },
@@ -9165,8 +9108,7 @@
                               "host": [
                                 "{{domain}}{{endpoint_carts_id_items}}"
                               ]
-                            },
-                            "description": null
+                            }
                           },
                           "response": []
                         },
@@ -9224,8 +9166,7 @@
                               "path": [
                                 "{{cartId}}"
                               ]
-                            },
-                            "description": null
+                            }
                           },
                           "response": []
                         }
@@ -9393,8 +9334,7 @@
                               "path": [
                                 "{{cartId}}"
                               ]
-                            },
-                            "description": null
+                            }
                           },
                           "response": []
                         },
@@ -9505,8 +9445,7 @@
                               "path": [
                                 "{{cartId}}"
                               ]
-                            },
-                            "description": null
+                            }
                           },
                           "response": []
                         },
@@ -9602,8 +9541,7 @@
                               "query": [
                                 {
                                   "key": "cartItemIds",
-                                  "value": "{{cart_items_to_remove}}COUPON_XXX",
-                                  "equals": true
+                                  "value": "{{cart_items_to_remove}}COUPON_XXX"
                                 }
                               ]
                             },
@@ -9868,8 +9806,7 @@
                               "path": [
                                 "me"
                               ]
-                            },
-                            "description": null
+                            }
                           },
                           "response": []
                         },
@@ -9973,8 +9910,7 @@
                               "path": [
                                 "me"
                               ]
-                            },
-                            "description": null
+                            }
                           },
                           "response": []
                         },
@@ -10078,8 +10014,7 @@
                               "path": [
                                 "me"
                               ]
-                            },
-                            "description": null
+                            }
                           },
                           "response": []
                         }
@@ -10253,8 +10188,7 @@
                               "path": [
                                 "me"
                               ]
-                            },
-                            "description": null
+                            }
                           },
                           "response": []
                         },
@@ -10359,8 +10293,7 @@
                               "path": [
                                 "me"
                               ]
-                            },
-                            "description": null
+                            }
                           },
                           "response": []
                         },
@@ -10465,8 +10398,7 @@
                               "path": [
                                 "me"
                               ]
-                            },
-                            "description": null
+                            }
                           },
                           "response": []
                         }
@@ -10642,8 +10574,7 @@
                           "path": [
                             "{{cartId}}"
                           ]
-                        },
-                        "description": null
+                        }
                       },
                       "response": []
                     },
@@ -10692,8 +10623,7 @@
                           "path": [
                             "{{cart_item_id}}"
                           ]
-                        },
-                        "description": null
+                        }
                       },
                       "response": []
                     },
@@ -10747,8 +10677,7 @@
                           "path": [
                             "{{cartId}}"
                           ]
-                        },
-                        "description": null
+                        }
                       },
                       "response": []
                     }
@@ -11312,8 +11241,7 @@
                           "path": [
                             "{{cartId}}"
                           ]
-                        },
-                        "description": null
+                        }
                       },
                       "response": []
                     },
@@ -11362,8 +11290,7 @@
                           "path": [
                             "{{cart_item_id}}"
                           ]
-                        },
-                        "description": null
+                        }
                       },
                       "response": []
                     },
@@ -11417,8 +11344,7 @@
                           "path": [
                             "{{cartId}}"
                           ]
-                        },
-                        "description": null
+                        }
                       },
                       "response": []
                     }
@@ -11646,8 +11572,7 @@
                           "path": [
                             "{{cartId}}"
                           ]
-                        },
-                        "description": null
+                        }
                       },
                       "response": []
                     },
@@ -11979,8 +11904,7 @@
                           "path": [
                             "{{cartId}}"
                           ]
-                        },
-                        "description": null
+                        }
                       },
                       "response": []
                     },
@@ -12268,8 +12192,7 @@
                   "host": [
                     "{{domain}}{{endpoint_carts_id_checkoutUrl}}"
                   ]
-                },
-                "description": null
+                }
               },
               "response": []
             }
@@ -12434,8 +12357,7 @@
                   "host": [
                     "{{domain}}{{endpoint_carts_id_checkoutUrl}}"
                   ]
-                },
-                "description": null
+                }
               },
               "response": []
             }
@@ -12823,8 +12745,7 @@
               "host": [
                 "{{domain}}{{endpoint_carts_id_customer}}"
               ]
-            },
-            "description": null
+            }
           },
           "response": []
         },
@@ -12930,8 +12851,7 @@
                 "me",
                 "customer"
               ]
-            },
-            "description": null
+            }
           },
           "response": []
         }
@@ -12989,8 +12909,7 @@
               "host": [
                 "{{domain}}{{endpoint_customers_me}}"
               ]
-            },
-            "description": null
+            }
           },
           "response": []
         },
@@ -13037,8 +12956,7 @@
               "host": [
                 "{{domain}}{{endpoint_customers_me}}"
               ]
-            },
-            "description": null
+            }
           },
           "response": []
         }
@@ -13100,8 +13018,7 @@
                   "host": [
                     "{{domain}}{{endpoint_products}}"
                   ]
-                },
-                "description": null
+                }
               },
               "response": []
             },
@@ -13156,12 +13073,10 @@
                   "query": [
                     {
                       "key": "category_id",
-                      "value": "10",
-                      "equals": true
+                      "value": "10"
                     }
                   ]
-                },
-                "description": null
+                }
               },
               "response": []
             },
@@ -13210,12 +13125,10 @@
                   "query": [
                     {
                       "key": "category_id",
-                      "value": "99999",
-                      "equals": true
+                      "value": "99999"
                     }
                   ]
-                },
-                "description": null
+                }
               },
               "response": []
             },
@@ -13270,17 +13183,14 @@
                   "query": [
                     {
                       "key": "page",
-                      "value": "1",
-                      "equals": true
+                      "value": "1"
                     },
                     {
                       "key": "limit",
-                      "value": "4",
-                      "equals": true
+                      "value": "4"
                     }
                   ]
-                },
-                "description": null
+                }
               },
               "response": []
             }
@@ -13339,8 +13249,7 @@
                   "host": [
                     "{{domain}}{{endpoint_products}}"
                   ]
-                },
-                "description": null
+                }
               },
               "response": []
             },
@@ -13395,12 +13304,10 @@
                   "query": [
                     {
                       "key": "category_id",
-                      "value": "10",
-                      "equals": true
+                      "value": "10"
                     }
                   ]
-                },
-                "description": null
+                }
               },
               "response": []
             },
@@ -13449,12 +13356,10 @@
                   "query": [
                     {
                       "key": "category_id",
-                      "value": "99999",
-                      "equals": true
+                      "value": "99999"
                     }
                   ]
-                },
-                "description": null
+                }
               },
               "response": []
             },
@@ -13509,17 +13414,14 @@
                   "query": [
                     {
                       "key": "page",
-                      "value": "1",
-                      "equals": true
+                      "value": "1"
                     },
                     {
                       "key": "limit",
-                      "value": "4",
-                      "equals": true
+                      "value": "4"
                     }
                   ]
-                },
-                "description": null
+                }
               },
               "response": []
             }
@@ -13823,8 +13725,7 @@
                   "path": [
                     "564"
                   ]
-                },
-                "description": null
+                }
               },
               "response": []
             },
@@ -13947,8 +13848,7 @@
                   "path": [
                     "370"
                   ]
-                },
-                "description": null
+                }
               },
               "response": []
             },
@@ -14012,8 +13912,7 @@
                   "path": [
                     "454"
                   ]
-                },
-                "description": null
+                }
               },
               "response": []
             }
@@ -14306,8 +14205,7 @@
                   "path": [
                     "564"
                   ]
-                },
-                "description": null
+                }
               },
               "response": []
             },
@@ -14428,8 +14326,7 @@
                   "path": [
                     "370"
                   ]
-                },
-                "description": null
+                }
               },
               "response": []
             },
@@ -14493,8 +14390,7 @@
                   "path": [
                     "454"
                   ]
-                },
-                "description": null
+                }
               },
               "response": []
             }
@@ -14627,6 +14523,7 @@
                     {
                       "listen": "test",
                       "script": {
+                        "id": "bb9c069e-9b1a-4913-9cf5-fd528527fe73",
                         "type": "text/javascript",
                         "exec": [
                           "pm.test(\"Successfully loaded cart via ME endpoint\", function () {",
@@ -14636,7 +14533,7 @@
                           "pm.test(\"Boots in cart with one added free\", function () {",
                           "    var jsonData = pm.response.json();",
                           "    pm.expect(jsonData.items_qty).to.eql(\"2.0000\");",
-                          "    pm.expect(jsonData.grand_total).to.eql(\"470.0000\");",
+                          "    pm.expect(parseFloat(jsonData.grand_total)).lessThan(471.0000);",
                           "});"
                         ]
                       }
@@ -14672,8 +14569,7 @@
                       "path": [
                         "me"
                       ]
-                    },
-                    "description": null
+                    }
                   },
                   "response": []
                 }
@@ -14853,8 +14749,7 @@
                       "path": [
                         "{{cartId}}"
                       ]
-                    },
-                    "description": null
+                    }
                   },
                   "response": []
                 }
@@ -14868,11 +14763,11 @@
     },
     {
       "name": "/v2/categories",
-      "description": "",
+      "description": null,
       "item": [
         {
           "name": "Customer",
-          "description": "",
+          "description": null,
           "item": [
             {
               "name": "Simple call",
@@ -14898,14 +14793,16 @@
                     "value": "application/json"
                   }
                 ],
-                "body": {},
+                "body": {
+                  "mode": "raw",
+                  "raw": ""
+                },
                 "url": {
                   "raw": "{{domain}}{{endpoint_categories}}",
                   "host": [
                     "{{domain}}{{endpoint_categories}}"
                   ]
-                },
-                "description": ""
+                }
               },
               "response": []
             }
@@ -14946,7 +14843,7 @@
         },
         {
           "name": "Guest",
-          "description": "",
+          "description": null,
           "item": [
             {
               "name": "Simple call",
@@ -14972,14 +14869,16 @@
                     "value": "application/json"
                   }
                 ],
-                "body": {},
+                "body": {
+                  "mode": "raw",
+                  "raw": ""
+                },
                 "url": {
                   "raw": "{{domain}}{{endpoint_categories}}",
                   "host": [
                     "{{domain}}{{endpoint_categories}}"
                   ]
-                },
-                "description": ""
+                }
               },
               "response": []
             }
@@ -15000,11 +14899,11 @@
     },
     {
       "name": "/v2/categories/:id",
-      "description": "",
+      "description": null,
       "item": [
         {
           "name": "Customer",
-          "description": "",
+          "description": null,
           "item": [
             {
               "name": "Simple call",
@@ -15030,7 +14929,10 @@
                     "value": "application/json"
                   }
                 ],
-                "body": {},
+                "body": {
+                  "mode": "raw",
+                  "raw": ""
+                },
                 "url": {
                   "raw": "{{domain}}{{endpoint_categories}}/1",
                   "host": [
@@ -15039,8 +14941,7 @@
                   "path": [
                     "1"
                   ]
-                },
-                "description": ""
+                }
               },
               "response": []
             }
@@ -15081,7 +14982,7 @@
         },
         {
           "name": "Guest",
-          "description": "",
+          "description": null,
           "item": [
             {
               "name": "Simple call",
@@ -15107,7 +15008,10 @@
                     "value": "application/json"
                   }
                 ],
-                "body": {},
+                "body": {
+                  "mode": "raw",
+                  "raw": ""
+                },
                 "url": {
                   "raw": "{{domain}}{{endpoint_categories}}/1",
                   "host": [
@@ -15116,8 +15020,7 @@
                   "path": [
                     "1"
                   ]
-                },
-                "description": ""
+                }
               },
               "response": []
             }
@@ -15176,8 +15079,7 @@
           "host": [
             "{{domain}}{{endpoint_auth_token}}"
           ]
-        },
-        "description": null
+        }
       },
       "response": []
     }


### PR DESCRIPTION
## Description

Fixes compatibility of `v2/products` endpoint when the price: include_tax is enabled. Enabled config in travis build to catch this error in the future.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md