### PR TITLE
Magento 2149 add region code

### DIFF
--- a/src/app/code/community/Shopgate/Cloudapi/Model/Api2/Customers/Addresses/Rest.php
+++ b/src/app/code/community/Shopgate/Cloudapi/Model/Api2/Customers/Addresses/Rest.php
@@ -77,7 +77,8 @@ class Shopgate_Cloudapi_Model_Api2_Customers_Addresses_Rest extends Shopgate_Clo
     protected function _retrieve()
     {
         /* @var $address Mage_Customer_Model_Address */
-        $address               = $this->_loadCustomerAddressById($this->getRequest()->getParam('id'));
+        $address = $this->_loadCustomerAddressById($this->getRequest()->getParam('id'));
+        $address->getRegionCode();
         $addressData           = $address->getData();
         $addressData['street'] = $address->getStreet();
 
@@ -95,6 +96,7 @@ class Shopgate_Cloudapi_Model_Api2_Customers_Addresses_Rest extends Shopgate_Clo
         $data = array();
         /* @var $address Mage_Customer_Model_Address */
         foreach ($this->_getCollectionForRetrieve() as $address) {
+            $address->getRegionCode();
             $addressData                     = $address->getData();
             $addressData['street']           = $address->getStreet();
             $addressData['customAttributes'] = $this->getCustomAttributes($address);

--- a/src/app/code/community/Shopgate/Cloudapi/Model/Api2/Customers/Addresses/Rest/Customer/V2.php
+++ b/src/app/code/community/Shopgate/Cloudapi/Model/Api2/Customers/Addresses/Rest/Customer/V2.php
@@ -36,7 +36,6 @@ class Shopgate_Cloudapi_Model_Api2_Customers_Addresses_Rest_Customer_V2
     {
         /* @var $customerAddress Mage_Customer_Model_Address */
         $customerAddress = parent::_loadCustomerAddressById($id);
-        // check owner
         if ($this->getApiUser()->getUserId() !== $customerAddress->getCustomerId()) {
             $this->_critical(self::RESOURCE_NOT_FOUND);
         }
@@ -57,7 +56,6 @@ class Shopgate_Cloudapi_Model_Api2_Customers_Addresses_Rest_Customer_V2
     {
         /* @var $customer Mage_Customer_Model_Customer */
         $customer = parent::_loadCustomerById($id);
-        // check customer account owner
         if ($this->getApiUser()->getUserId() !== $customer->getId()) {
             $this->_critical(self::RESOURCE_NOT_FOUND);
         }

--- a/src/shell/shopgate_cloudapi.php
+++ b/src/shell/shopgate_cloudapi.php
@@ -35,6 +35,7 @@ class Shopgate_Cloudapi_Shell extends Mage_Shell_Abstract
     public function run()
     {
         if ($this->getArg('acl')) {
+            $this->cleanCaches();
             if ($this->getArg('attributes')) {
                 $this->updateAclAttributes();
 
@@ -47,7 +48,7 @@ class Shopgate_Cloudapi_Shell extends Mage_Shell_Abstract
             }
         }
 
-        $this->usageHelp();
+        die($this->usageHelp());
     }
 
     /**
@@ -77,6 +78,20 @@ class Shopgate_Cloudapi_Shell extends Mage_Shell_Abstract
             $role = $this->getRoleHelper()->createAdminRole();
         }
         $this->getRuleHelper()->addAclRules($role->getId());
+    }
+
+    /**
+     * Clean the config & API2 caches
+     */
+    private function cleanCaches()
+    {
+        $cache = Mage::app()->getCacheInstance();
+        foreach (array('config', 'config_api2') as $type) {
+            if ($cache->canUse($type)) {
+                $cache->cleanType($type);
+                Mage::dispatchEvent('adminhtml_cache_refresh_type', array('type' => $type));
+            }
+        }
     }
 
     /**

--- a/tests/postman/newman/collection.json
+++ b/tests/postman/newman/collection.json
@@ -15043,7 +15043,7 @@
                 {
                   "listen": "test",
                   "script": {
-                    "id": "50a057c1-3a2b-4288-9af5-192ce60da704",
+                    "id": "710b0cb7-da08-4fa7-b07e-770488fd65af",
                     "type": "text/javascript",
                     "exec": [
                       "pm.test(\"Successfully loaded address data\", function () {",
@@ -15053,21 +15053,22 @@
                       "pm.test(\"Customer address data is returned\", function () {",
                       "    const jsonData = pm.response.json();",
                       "    const lastAddress = jsonData.pop();",
-                      "    pm.expect(lastAddress.customer_id).to.eq(pm.environment.get(\"customer-id\"));",
+                      "    pm.expect(lastAddress.customer_id).to.be.a('string').to.eq(pm.environment.get(\"customer-id\"));",
                       "    pm.expect(lastAddress.created_at).to.not.be.empty;",
                       "    pm.expect(lastAddress.updated_at).to.not.be.empty;",
                       "    pm.expect(lastAddress.firstname).to.eq(pm.environment.get(\"seed\") + \".first\");",
                       "    pm.expect(lastAddress.lastname).to.eq(pm.environment.get(\"seed\") + \".last\");",
-                      "    pm.expect(lastAddress.is_active).to.eq('1');",
+                      "    pm.expect(lastAddress.is_active).to.be.a('string').to.eq('1');",
                       "    pm.expect(lastAddress.company).to.eq(pm.environment.get(\"seed\") + \".company\");",
                       "    pm.expect(lastAddress.city).to.eq(pm.environment.get(\"seed\") + \".city\");",
                       "    pm.expect(lastAddress.country_id).to.eq(\"US\");",
                       "    pm.expect(lastAddress.region).to.eq(\"Arizona\");",
-                      "    pm.expect(lastAddress.postcode).to.eq(\"85000\");",
+                      "    pm.expect(lastAddress.region_code).to.eq(\"AZ\");",
+                      "    pm.expect(lastAddress.postcode).to.be.a('string').to.eq(\"85000\");",
                       "    pm.expect(lastAddress.street[0]).to.eq(pm.environment.get(\"seed\") + \".street1\");",
                       "    pm.expect(lastAddress.street[1]).to.eq(pm.environment.get(\"seed\") + \".street2\");",
                       "    pm.expect(lastAddress.telephone).to.eq(pm.environment.get(\"seed\") + \".phone\");",
-                      "    pm.expect(lastAddress.vat_id).to.eq(pm.environment.get(\"seed\") + \".vat_id\");",
+                      "    pm.expect(lastAddress.vat_id).to.be.a('string').to.eq(pm.environment.get(\"seed\") + \".vat_id\");",
                       "});"
                     ]
                   }
@@ -15120,7 +15121,7 @@
                 {
                   "listen": "test",
                   "script": {
-                    "id": "a4db5316-86f5-4c77-ae9d-2a8f07740f5f",
+                    "id": "a47455e0-49e9-4fdc-9d13-79dbdb8e02eb",
                     "type": "text/javascript",
                     "exec": [
                       "pm.test(\"Successfully loaded address data\", function () {",
@@ -15133,16 +15134,17 @@
                       "    pm.expect(lastAddress.updated_at).to.not.be.empty;",
                       "    pm.expect(lastAddress.firstname).to.eq(pm.environment.get(\"seed\") + \".first\");",
                       "    pm.expect(lastAddress.lastname).to.eq(pm.environment.get(\"seed\") + \".last\");",
-                      "    pm.expect(lastAddress.is_active).to.eq('1');",
+                      "    pm.expect(lastAddress.is_active).to.be.a('string').to.eq('1');",
                       "    pm.expect(lastAddress.company).to.eq(pm.environment.get(\"seed\") + \".company\");",
                       "    pm.expect(lastAddress.city).to.eq(pm.environment.get(\"seed\") + \".city\");",
                       "    pm.expect(lastAddress.country_id).to.eq(\"US\");",
                       "    pm.expect(lastAddress.region).to.eq(\"Arizona\");",
-                      "    pm.expect(lastAddress.postcode).to.eq(\"85000\");",
+                      "    pm.expect(lastAddress.region_code).to.eq(\"AZ\");",
+                      "    pm.expect(lastAddress.postcode).to.be.a('string').to.eq(\"85000\");",
                       "    pm.expect(lastAddress.street[0]).to.eq(pm.environment.get(\"seed\") + \".street1\");",
                       "    pm.expect(lastAddress.street[1]).to.eq(pm.environment.get(\"seed\") + \".street2\");",
                       "    pm.expect(lastAddress.telephone).to.eq(pm.environment.get(\"seed\") + \".phone\");",
-                      "    pm.expect(lastAddress.vat_id).to.eq(pm.environment.get(\"seed\") + \".vat_id\");",
+                      "    pm.expect(lastAddress.vat_id).to.be.a('string').to.eq(pm.environment.get(\"seed\") + \".vat_id\");",
                       "});"
                     ]
                   }


### PR DESCRIPTION
## Description

Added `region_code` ISO2 to address export. Omitted implementation in getUser as that will not have addresses returned later.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I updated the CHANGELOG.md
