### PR TITLE
Missing cronjob file

### DIFF
--- a/src/app/code/community/Shopgate/Cloudapi/etc/config.xml
+++ b/src/app/code/community/Shopgate/Cloudapi/etc/config.xml
@@ -290,18 +290,6 @@
             </modules>
         </translate>
     </frontend>
-    <crontab>
-        <jobs>
-            <shopgate_cloudapi_delete_expired_tokens>
-                <schedule>
-                    <cron_expr>0 1 * * 0</cron_expr><!-- Every Sunday at 1 am-->
-                </schedule>
-                <run>
-                    <model>shopgate_cloudapi/observer::deleteExpiredTokens</model>
-                </run>
-            </shopgate_cloudapi_delete_expired_tokens>
-        </jobs>
-    </crontab>
     <default>
         <shopgate_cloudapi>
             <layout>


### PR DESCRIPTION
# Pull Request Template

## Description

The class Shopgate_Cloudapi_Model_Observer does not exist, so the cronjob cannot be executed. Maybe the missing file should be added?

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I updated the CHANGELOG.md
